### PR TITLE
Bug fix on transmission table parse

### DIFF
--- a/reV/handlers/transmission.py
+++ b/reV/handlers/transmission.py
@@ -239,6 +239,7 @@ class TransmissionFeatures:
                     if gid not in missing:
                         missing[gid] = []
                     missing[gid].append(line_gid)
+
         if any(missing):
             emsg = ('Transmission feature table has {} parent features that '
                     'depend on missing lines. Missing dependencies: {}'

--- a/reV/handlers/transmission.py
+++ b/reV/handlers/transmission.py
@@ -48,6 +48,7 @@ class TransmissionFeatures:
             attached lines, legacy method
         """
 
+        logger.debug('Trans table input: {}'.format(trans_table))
         logger.debug('Line tie in cost: {} $/MW'.format(line_tie_in_cost))
         logger.debug('Line cost: {} $/MW-mile'.format(line_cost))
         logger.debug('Station tie in cost: {} $/MW'
@@ -68,6 +69,7 @@ class TransmissionFeatures:
         self._available_capacity_frac = available_capacity
 
         self._features = self._get_features(trans_table)
+        self._check_feature_dependencies()
 
         self._feature_gid_list = list(self._features.keys())
         self._available_mask = np.ones(
@@ -227,6 +229,22 @@ class TransmissionFeatures:
         features = self._features_from_table(trans_table)
 
         return features
+
+    def _check_feature_dependencies(self):
+        """Check features for dependencies that are missing and raise error."""
+        missing = {}
+        for gid, feature_dict in self._features.items():
+            for line_gid in feature_dict.get('lines', []):
+                if line_gid not in self._features:
+                    if gid not in missing:
+                        missing[gid] = []
+                    missing[gid].append(line_gid)
+        if any(missing):
+            emsg = ('Transmission feature table has {} parent features that '
+                    'depend on missing lines. Missing dependencies: {}'
+                    .format(len(missing), missing))
+            logger.error(emsg)
+            raise RuntimeError(emsg)
 
     @staticmethod
     def _calc_cost(distance, line_cost=3667, tie_in_cost=0,

--- a/reV/supply_curve/supply_curve.py
+++ b/reV/supply_curve/supply_curve.py
@@ -62,23 +62,23 @@ class SupplyCurve:
         trans_costs = transmission_costs
         self._sc_points = self._parse_sc_points(sc_points,
                                                 sc_features=sc_features)
-        self._trans_table = self._parse_trans_table(self._sc_points,
-                                                    trans_table, fcr,
-                                                    trans_costs=trans_costs,
-                                                    line_limited=line_limited,
-                                                    connectable=connectable,
-                                                    max_workers=max_workers)
+        self._trans_table = self._parse_trans_table(trans_table)
+        self._trans_table = self._merge_sc_trans_tables(self._sc_points,
+                                                        self._trans_table)
+        self._check_sc_trans_table(self._sc_points, self._trans_table)
+        self._trans_table = self._add_trans_lcot(self._trans_table, fcr,
+                                                 trans_costs=trans_costs,
+                                                 line_limited=line_limited,
+                                                 connectable=connectable,
+                                                 max_workers=max_workers)
         self._trans_features = self._create_handler(self._trans_table,
                                                     trans_costs=trans_costs)
 
         self._consider_friction = consider_friction
         self._calculate_total_lcoe_friction()
 
-        mask = ~pd.isna(self._trans_table['sc_gid'])
-        self._trans_table = self._trans_table[mask]
-        self._sc_gids = list(np.sort(self._trans_table['sc_gid'].unique()))
-        self._sc_gids = [int(gid) for gid in self._sc_gids]
-        self._mask = np.ones((int(1 + max(self._sc_gids)), ), dtype=bool)
+        out = self._parse_sc_gids(self._trans_table)
+        self._trans_table, self._sc_gids, self._mask = out
 
     def __repr__(self):
         msg = "{} with {} points".format(self.__class__.__name__, len(self))
@@ -105,7 +105,7 @@ class SupplyCurve:
 
         Parameters
         ----------
-        table : str
+        table : str | pd.DataFrame
             Path to .csv or .json or DataFrame to parse
 
         Returns
@@ -162,6 +162,38 @@ class SupplyCurve:
                      .format(sc_points.columns.values.tolist()))
 
         return sc_points
+
+    @staticmethod
+    def _parse_sc_gids(trans_table, gid_key='sc_gid'):
+        """Filter the trans table, extract unique sc gids, make bool mask.
+
+        Parameters
+        ----------
+        trans_table : pd.DataFrame
+            reV Supply Curve table joined with transmission features table.
+        gid_key : str
+            Column label in trans_table containing the supply curve points
+            primary key.
+
+        Returns
+        -------
+        trans_table : pd.DataFrame
+            Same as input but filtered to only include non-nan
+            supply curve gids.
+        sc_gids : list
+            List of unique integer supply curve gids (non-nan)
+        mask : np.ndarray
+            Boolean array initialized as true. Length is equal to the maximum
+            SC gid so that the SC gids can be used to index the mask directly.
+        """
+
+        filter_mask = ~pd.isna(trans_table[gid_key])
+        trans_table = trans_table[filter_mask]
+        sc_gids = list(np.sort(trans_table[gid_key].unique()))
+        sc_gids = [int(gid) for gid in sc_gids]
+        mask = np.ones((int(1 + max(sc_gids)), ), dtype=bool)
+
+        return trans_table, sc_gids, mask
 
     @staticmethod
     def _create_handler(trans_table, trans_costs=None):
@@ -261,9 +293,11 @@ class SupplyCurve:
         if max_workers is None:
             max_workers = os.cpu_count()
 
+        gid_mask = ~pd.isna(trans_table['sc_gid'])
+
         logger.info('Computing LCOT costs for all possible connections...')
         if max_workers > 1:
-            groups = trans_table.groupby('sc_gid')
+            groups = trans_table[gid_mask].groupby('sc_gid')
             with SpawnProcessPool(max_workers=max_workers) as exe:
                 futures = []
                 for sc_gid, sc_table in groups:
@@ -291,8 +325,7 @@ class SupplyCurve:
             feature = TC(trans_table, line_limited=line_limited,
                          **trans_costs)
             cost = []
-            iterrows = trans_table[~pd.isna(trans_table['sc_gid'])].iterrows()
-            for _, row in iterrows:
+            for _, row in trans_table[gid_mask].iterrows():
                 if connectable:
                     capacity = row['capacity']
                 else:
@@ -305,8 +338,7 @@ class SupplyCurve:
 
             cost = np.array(cost, dtype='float32')
 
-        mask = ~pd.isna(trans_table['sc_gid'])
-        cf_mean_arr = trans_table.loc[mask, 'mean_cf'].values
+        cf_mean_arr = trans_table.loc[gid_mask, 'mean_cf'].values
         lcot = (cost * fcr) / (cf_mean_arr * 8760)
 
         logger.info('LCOT cost calculation is complete.')
@@ -347,47 +379,21 @@ class SupplyCurve:
         return trans_table
 
     @staticmethod
-    def _parse_trans_table(sc_points, trans_table, fcr, trans_costs=None,
-                           line_limited=False, connectable=True,
-                           max_workers=None,
-                           merge_cols=('capacity', 'sc_gid', 'mean_cf',
-                                       'mean_lcoe')):
+    def _parse_trans_table(trans_table):
         """
-        Import supply curve table, add in supply curve point capacity
+        Import transmission features table
 
         Parameters
         ----------
-        sc_points : pd.DataFrame
-            Table of supply curve point summary
-        trans_table : pd.DataFrame
+        trans_table : pd.DataFrame | str
             Table mapping supply curve points to transmission features
-        fcr : float
-            Fixed charge rate, used to compute LCOT
-        trans_costs : str | dict
-            Transmission feature costs to use with TransmissionFeatures
-            handler: line_tie_in_cost, line_cost, station_tie_in_cost,
-            center_tie_in_cost, sink_tie_in_cost
-        line_limited : bool
-            Substation connection is limited by maximum capacity of the
-            attached lines, legacy method
-        connectable : bool
-            Determine if connection is possible
-        max_workers : int | NoneType
-            Number of workers to use to compute lcot, if > 1 run in parallel.
-            None uses all available cpu's.
-        merge_cols : tuple | list
-            List of column from sc_points to merge into the trans table.
+            (either str filepath to table file or pre-loaded dataframe).
 
         Returns
         -------
         trans_table : pd.DataFrame
-            Updated table mapping supply curve points to transmission features
+            Loaded transmission feature table.
         """
-        if isinstance(merge_cols, tuple):
-            merge_cols = list(merge_cols)
-
-        if 'mean_lcoe_friction' in sc_points:
-            merge_cols.append('mean_lcoe_friction')
 
         trans_table = SupplyCurve._load_table(trans_table)
 
@@ -395,6 +401,75 @@ class SupplyCurve:
         for col in drop_cols:
             if col in trans_table:
                 trans_table = trans_table.drop(col, axis=1)
+
+        return trans_table
+
+    @staticmethod
+    def _check_sc_trans_table(sc_points, trans_table):
+        """Run self checks on sc_points table and the merged trans_table
+
+        Parameters
+        ----------
+        sc_points : pd.DataFrame
+            Table of supply curve point summary
+        trans_table : pd.DataFrame
+            Table mapping supply curve points to transmission features
+            (should already be merged with SC points).
+        """
+        sc_gids = set(sc_points['sc_gid'].unique())
+        trans_sc_gids = set(trans_table['sc_gid'].unique())
+        missing = sorted(list(sc_gids - trans_sc_gids))
+        if any(missing):
+            msg = ("There are {} Supply Curve points with missing "
+                   "transmission mappings. Supply curve points with no "
+                   "transmission features will not be connected! "
+                   "Missing sc_gid's: {}"
+                   .format(len(missing), missing))
+            logger.warning(msg)
+            warn(msg)
+
+        if not any(trans_sc_gids) or not any(sc_gids):
+            msg = ('Merging of sc points table and transmission features '
+                   'table failed with {} original sc gids and {} transmission '
+                   'sc gids after table merge.'
+                   .format(len(sc_gids), len(trans_sc_gids)))
+            logger.error(msg)
+            raise SupplyCurveError(msg)
+
+        logger.debug('There are {} original SC gids and {} sc gids in the '
+                     'merged transmission table.'
+                     .format(len(sc_gids), len(trans_sc_gids)))
+        logger.debug('Transmission Table created with columns: {}'
+                     .format(trans_table.columns.values.tolist()))
+
+    @staticmethod
+    def _merge_sc_trans_tables(sc_points, trans_table,
+                               merge_cols=('capacity', 'sc_gid', 'mean_cf',
+                                           'mean_lcoe')):
+        """Merge the supply curve table with the transmission features table.
+
+        Parameters
+        ----------
+        sc_points : pd.DataFrame
+            Table of supply curve point summary
+        trans_table : pd.DataFrame
+            Table mapping supply curve points to transmission features
+        merge_cols : tuple | list
+            List of column from sc_points to merge into the trans table.
+
+        Returns
+        -------
+        trans_table : pd.DataFrame
+            Updated table mapping supply curve points to transmission features.
+            This is performed by merging left with trans_table, so there may be
+            rows with nan sc_gid.
+        """
+
+        if isinstance(merge_cols, tuple):
+            merge_cols = list(merge_cols)
+
+        if 'mean_lcoe_friction' in sc_points:
+            merge_cols.append('mean_lcoe_friction')
 
         point_merge_cols = SupplyCurve._get_merge_cols(sc_points.columns)
         table_merge_cols = SupplyCurve._get_merge_cols(trans_table.columns)
@@ -413,29 +488,39 @@ class SupplyCurve:
                      .format(table_merge_cols))
         trans_table = trans_table.merge(sc_cap, on=table_merge_cols,
                                         how='left')
+        return trans_table
 
-        sc_gids = set(sc_cap['sc_gid'].unique())
-        trans_sc_gids = set(trans_table['sc_gid'].unique())
-        missing = sorted(list(sc_gids - trans_sc_gids))
-        if any(missing):
-            msg = ("There are {} Supply Curve points with missing "
-                   "transmission mappings. Supply curve points with no "
-                   "transmission features will not be connected! "
-                   "Missing sc_gid's: {}"
-                   .format(len(missing), missing))
-            logger.warning(msg)
-            warn(msg)
-        if not any(trans_sc_gids) or not any(sc_gids):
-            msg = ('Merging of sc points table and transmission features '
-                   'table failed with {} original sc gids and {} transmission '
-                   'sc gids after table merge.'
-                   .format(len(sc_gids), len(trans_sc_gids)))
-            logger.error(msg)
-            raise SupplyCurveError(msg)
+    @staticmethod
+    def _add_trans_lcot(trans_table, fcr, trans_costs=None,
+                        line_limited=False, connectable=True,
+                        max_workers=None):
+        """Compute LCOT for possible connections and add to the trans_table
 
-        logger.debug('There are {} original SC gids and {} sc gids in the '
-                     'merged transmission table.'
-                     .format(len(sc_gids), len(trans_sc_gids)))
+        Parameters
+        ----------
+        trans_table : pd.DataFrame
+            Table mapping supply curve points to transmission features.
+        fcr : float
+            Fixed charge rate, used to compute LCOT
+        trans_costs : str | dict | None
+            Transmission feature costs to use with TransmissionFeatures
+            handler: line_tie_in_cost, line_cost, station_tie_in_cost,
+            center_tie_in_cost, sink_tie_in_cost
+        line_limited : bool
+            Substation connection is limited by maximum capacity of the
+            attached lines, legacy method
+        connectable : bool
+            Determine if connection is possible
+        max_workers : int | NoneType
+            Number of workers to use to compute lcot, if > 1 run in parallel.
+            None uses all available cpu's.
+
+        Returns
+        -------
+        trans_table : pd.DataFrame
+            Same as input table but with new columns for trans_cap_cost, lcot,
+            and total_lcoe.
+        """
 
         trans_table = SupplyCurve._feature_capacity(trans_table,
                                                     trans_costs=trans_costs)
@@ -446,15 +531,11 @@ class SupplyCurve:
                                                connectable=connectable,
                                                max_workers=max_workers)
 
-        mask = ~pd.isna(trans_table['sc_gid'])
-        trans_table.loc[mask, 'trans_cap_cost'] = cost
-        trans_table.loc[mask, 'lcot'] = lcot
+        gid_mask = ~pd.isna(trans_table['sc_gid'])
+        trans_table.loc[gid_mask, 'trans_cap_cost'] = cost
+        trans_table.loc[gid_mask, 'lcot'] = lcot
         trans_table['total_lcoe'] = (trans_table['lcot']
                                      + trans_table['mean_lcoe'])
-
-        logger.debug('Transmission Table created with columns: {}'
-                     .format(trans_table.columns.values.tolist()))
-
         return trans_table
 
     def _calculate_total_lcoe_friction(self):


### PR DESCRIPTION
So I think there's actually a bug in the CAN transmission data, where an SC point will connect to a substation but not that one line belonging to the substation. The reV SC module merges the SC and Transmission tables and would previously drop any transmission features that doesnt connect to one of the active SC points (a line belonging to an important substation was getting dropped). Now it maintains ALL of the transmission features and drops those that don't connect to an SC point at the very end before the SC sorted buildout. 