### PR TITLE
Output attrs

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -20,6 +20,7 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_PYTHON_BLACK: false
           VALIDATE_PYTHON_ISORT: false
+          VALIDATE_PYTHON_MYPY: false
           VALIDATE_JSCPD: false
           VALIDATE_JSON: false
           VALIDATE_MARKDOWN: false

--- a/reV/handlers/collection.py
+++ b/reV/handlers/collection.py
@@ -288,7 +288,6 @@ class DatasetCollector:
         with Outputs(self._h5_file, mode='a') as f_out:
             for fp in self._source_files:
                 with Outputs(fp, mode='r') as f_source:
-
                     x = self._get_source_gid_chunks(f_source)
                     all_source_gids, source_gid_chunks = x
 
@@ -482,7 +481,7 @@ class Collector:
             Dataset shape tuple.
         """
         with Outputs(self.h5_files[0], mode='r') as f:
-            shape, _, _ = f.get_dset_properties(dset_name)
+            shape = f.shapes[dset_name]
 
         return shape
 
@@ -570,6 +569,7 @@ class Collector:
 
         with Outputs(self._h5_out, mode='r') as out:
             dsets_collected = out.datasets
+
         with Outputs(self.h5_files[0], mode='r') as out:
             dsets_source = out.datasets
 

--- a/reV/version.py
+++ b/reV/version.py
@@ -2,4 +2,4 @@
 reV Version number
 """
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 NREL-NRWAL>=0.0.1
 NREL-PySAM>=2.2.2
-NREL-rex>=0.2.52
+NREL-rex>=0.2.54
 packaging>=20.3
 plotly>=4.7.1
 plotting>=0.0.6

--- a/tests/test_gen_config.py
+++ b/tests/test_gen_config.py
@@ -102,6 +102,7 @@ def test_gen_from_config(runner, tech):  # noqa: C901
         # get reV 2.0 generation profiles from disk
         rev2_profiles = None
         flist = os.listdir(config_obj.dirout)
+        print(flist)
         for fname in flist:
             if job_name in fname and fname.endswith('.h5'):
                 path = os.path.join(config_obj.dirout, fname)
@@ -109,6 +110,8 @@ def test_gen_from_config(runner, tech):  # noqa: C901
 
                     msg = 'cf_profile not written to disk'
                     assert 'cf_profile' in cf.datasets, msg
+                    print(cf.scale_factors['cf_profile'])
+                    print(cf.dtypes['cf_profile'])
                     rev2_profiles = cf['cf_profile']
 
                     msg = 'monthly_energy not written to disk'
@@ -131,6 +134,9 @@ def test_gen_from_config(runner, tech):  # noqa: C901
 
         result = np.allclose(rev1_profiles, rev2_profiles,
                              rtol=RTOL, atol=ATOL)
+
+        print(rev1_profiles)
+        print(rev2_profiles)
 
         LOGGERS.clear()
         msg = ('reV generation from config input failed for "{}" module!'

--- a/tests/test_handlers_outputs.py
+++ b/tests/test_handlers_outputs.py
@@ -53,16 +53,23 @@ def test_add_dset():
             f.time_index = time_index
 
         with pytest.raises(HandlerRuntimeError):
-            f.add_dataset(fp, 'dset1', arr1, None, int, chunks=None,
-                          unscale=True, mode='a', str_decode=True,
-                          group=None)
+            Outputs.add_dataset(fp, 'dset1', arr1, int, attrs=None,
+                                chunks=None, unscale=True, mode='a',
+                                str_decode=True, group=None)
 
         with pytest.raises(HandlerRuntimeError):
-            Outputs.add_dataset(fp, 'dset2', arr2, {'scale_factor': 1}, int,
+            Outputs.add_dataset(fp, 'dset2', arr2, int,
+                                attrs={'scale_factor': 1},
                                 chunks=(None, 10), unscale=True, mode='a',
                                 str_decode=True, group=None)
 
-        Outputs.add_dataset(fp, 'dset1', arr1.astype(int), None, int,
+        with pytest.raises(HandlerRuntimeError):
+            Outputs.add_dataset(fp, 'dset1', arr2, float,
+                                attrs={'scale_factor': 10},
+                                chunks=(None, 10), unscale=True, mode='a',
+                                str_decode=True, group=None)
+
+        Outputs.add_dataset(fp, 'dset1', arr1.astype(int), int, attrs=None,
                             chunks=None, unscale=True, mode='a',
                             str_decode=True, group=None)
 
@@ -73,7 +80,8 @@ def test_add_dset():
             assert np.allclose(arr1, data)
 
         Outputs.add_dataset(fp, 'dset2', arr2.astype(np.int16),
-                            {'scale_factor': 1}, np.int16, chunks=(None, 10),
+                            np.int16, attrs={'scale_factor': 1},
+                            chunks=(None, 10),
                             unscale=True, mode='a', str_decode=True,
                             group=None)
 
@@ -84,7 +92,8 @@ def test_add_dset():
             assert f['dset2'].chunks == (8760, 10)
             assert np.allclose(f['dset2'][...], arr2)
 
-        Outputs.add_dataset(fp, 'dset3', arr3, {'scale_factor': 100}, np.int32,
+        Outputs.add_dataset(fp, 'dset3', arr3, np.int32,
+                            attrs={'scale_factor': 100},
                             chunks=(100, 25),
                             unscale=True, mode='a', str_decode=True,
                             group=None)
@@ -112,10 +121,11 @@ def test_bad_shape():
             f.time_index = time_index
 
         with pytest.raises(HandlerValueError):
-            Outputs.add_dataset(fp, 'dset3', np.ones(10), None, float)
+            Outputs.add_dataset(fp, 'dset3', np.ones(10), float, attrs=None)
 
         with pytest.raises(HandlerValueError):
-            Outputs.add_dataset(fp, 'dset3', np.ones((10, 10)), None, float)
+            Outputs.add_dataset(fp, 'dset3', np.ones((10, 10)), float,
+                                attrs=None)
 
 
 def execute_pytest(capture='all', flags='-rapP'):

--- a/tests/test_handlers_outputs.py
+++ b/tests/test_handlers_outputs.py
@@ -58,46 +58,64 @@ def test_add_dset():
                                 str_decode=True, group=None)
 
         with pytest.raises(HandlerRuntimeError):
-            Outputs.add_dataset(fp, 'dset2', arr2, int,
-                                attrs={'scale_factor': 1},
-                                chunks=(None, 10), unscale=True, mode='a',
-                                str_decode=True, group=None)
-
-        with pytest.raises(HandlerRuntimeError):
-            Outputs.add_dataset(fp, 'dset1', arr2, float,
+            Outputs.add_dataset(fp, 'dset2', arr2, float,
                                 attrs={'scale_factor': 10},
                                 chunks=(None, 10), unscale=True, mode='a',
                                 str_decode=True, group=None)
 
-        Outputs.add_dataset(fp, 'dset1', arr1.astype(int), int, attrs=None,
-                            chunks=None, unscale=True, mode='a',
+        # Float to float
+        Outputs.add_dataset(fp, 'dset1', arr1, arr1.dtype,
+                            attrs=None,
+                            unscale=True, mode='a',
                             str_decode=True, group=None)
-
         with h5py.File(fp, 'r') as f:
             assert 'dset1' in f
             data = f['dset1'][...]
-            assert data.dtype == int
+            assert data.dtype == float
             assert np.allclose(arr1, data)
 
-        Outputs.add_dataset(fp, 'dset2', arr2.astype(np.int16),
+        # Float to float
+        Outputs.add_dataset(fp, 'dset1', arr1, arr1.dtype,
+                            attrs={'scale_factor': 1},
+                            unscale=True, mode='a',
+                            str_decode=True, group=None)
+        with h5py.File(fp, 'r') as f:
+            assert 'dset1' in f
+            data = f['dset1'][...]
+            assert data.dtype == float
+            assert np.allclose(arr1, data)
+
+        # int16 to in16
+        Outputs.add_dataset(fp, 'dset1', arr1.astype(np.int16), np.int16,
+                            attrs=None,
+                            chunks=None, unscale=True, mode='a',
+                            str_decode=True, group=None)
+        with h5py.File(fp, 'r') as f:
+            assert 'dset1' in f
+            data = f['dset1'][...]
+            assert np.issubdtype(data.dtype, np.integer)
+            assert np.allclose(arr1, data)
+
+        # float to in16
+        Outputs.add_dataset(fp, 'dset2', arr2,
                             np.int16, attrs={'scale_factor': 1},
                             chunks=(None, 10),
                             unscale=True, mode='a', str_decode=True,
                             group=None)
-
         with h5py.File(fp, 'r') as f:
             assert 'dset1' in f
             assert 'dset2' in f
             assert f['dset1'].chunks is None
             assert f['dset2'].chunks == (8760, 10)
-            assert np.allclose(f['dset2'][...], arr2)
+            assert np.allclose(f['dset2'][...],
+                               np.round(arr2).astype(np.int16))
 
+        # scale to int32
         Outputs.add_dataset(fp, 'dset3', arr3, np.int32,
                             attrs={'scale_factor': 100},
                             chunks=(100, 25),
                             unscale=True, mode='a', str_decode=True,
                             group=None)
-
         with h5py.File(fp, 'r') as f:
             assert 'dset1' in f
             assert 'dset2' in f


### PR DESCRIPTION
Inits Outputs from BaseResource to ensure Outputs has all of the "Resource" attributes, properties, and methods
Updates the check_data_dtype method to:
1) if scale factor is user-defined (not None):
    - If scale factor is not 1 than output dtype must be an integer
    - If input and output dtype are not the same parent dtype (i.e float vs int) than scale, round, and change dtype
 2) if no scale factor is provided than input and output dtypes must be the same
Closes #300 
