### PR TITLE
Meta now defaults to rev_summary if running aggregate profiles

### DIFF
--- a/reV/rep_profiles/cli_rep_profiles.py
+++ b/reV/rep_profiles/cli_rep_profiles.py
@@ -225,6 +225,7 @@ def direct(ctx, gen_fpath, rev_summary, reg_cols, cf_dset, rep_method,
         if aggregate_profiles:
             RepProfiles.run(gen_fpath, rev_summary, reg_cols, cf_dset=cf_dset,
                             err_method=None, weight=weight, fout=fout,
+                            save_rev_summary=False,
                             max_workers=max_workers)
         else:
             RepProfiles.run(gen_fpath, rev_summary, reg_cols, cf_dset=cf_dset,

--- a/reV/rep_profiles/rep_profiles.py
+++ b/reV/rep_profiles/rep_profiles.py
@@ -921,10 +921,13 @@ class RepProfiles(RepProfilesBase):
     def _set_meta(self):
         """Set the rep profile meta data with each row being a unique
         combination of the region columns."""
-        self._meta = self._rev_summary.groupby(self._reg_cols)
-        self._meta = \
-            self._meta['timezone'].apply(lambda x: stats.mode(x).mode[0])
-        self._meta = self._meta.reset_index()
+        if self._err_method is None:
+            self._meta = self._rev_summary
+        else:
+            self._meta = self._rev_summary.groupby(self._reg_cols)
+            self._meta = \
+                self._meta['timezone'].apply(lambda x: stats.mode(x).mode[0])
+            self._meta = self._meta.reset_index()
 
         self._meta['rep_gen_gid'] = None
         self._meta['rep_res_gid'] = None

--- a/tests/test_rep_profiles.py
+++ b/tests/test_rep_profiles.py
@@ -7,6 +7,7 @@ import pandas as pd
 import numpy as np
 import json
 import tempfile
+from pandas.testing import assert_frame_equal
 
 from reV.rep_profiles.rep_profiles import (RegionRepProfile, RepProfiles,
                                            RepresentativeMethods)
@@ -152,11 +153,11 @@ def test_agg_profile():
                                 'gid_counts': gid_counts,
                                 'timezone': timezone})
 
-    profiles = RepProfiles.run(GEN_FPATH, rev_summary, 'sc_gid',
-                               cf_dset='cf_profile',
-                               scaled_precision=False,
-                               err_method=None,
-                               max_workers=None)[0]
+    profiles, p_meta, __ = RepProfiles.run(GEN_FPATH, rev_summary, 'sc_gid',
+                                           cf_dset='cf_profile',
+                                           scaled_precision=False,
+                                           err_method=None,
+                                           max_workers=None)
 
     for index in rev_summary.index:
         gen_gids = json.loads(rev_summary.loc[index, 'gen_gids'])
@@ -175,6 +176,15 @@ def test_agg_profile():
         truth = truth / weights.sum()
 
         assert np.allclose(profiles[0][:, index], truth)
+
+    passthrough_cols = ['gen_gids', 'res_gids', 'gid_counts']
+    for col in passthrough_cols:
+        assert col in p_meta
+
+    assert_frame_equal(
+        rev_summary[passthrough_cols],
+        p_meta[passthrough_cols]
+    )
 
 
 def test_many_regions():


### PR DESCRIPTION
The meta `DataFrame` of the output of RepProfiles had no value when running in aggregate mode. The only columns it contained were 'sc_gid', 'timezone', 'rep_gen_gid', and 'rep_res_gid', the latter two being `None` for all values since aggregate profiles have no representative profile. In this update, the meta DataFrame defaults to the required input `rev_summary` if running in aggregate mode. This means the new meta `DataFrame` contains 'sc_gid' and 'timezone', but also all other  `rev_summary` columns