### PR TITLE
NRWAL constant equation output request fix

### DIFF
--- a/reV/nrwal/nrwal.py
+++ b/reV/nrwal/nrwal.py
@@ -569,7 +569,7 @@ class RevNrwal:
     def _value_to_array(self, value, name):
         """Turn the input into numpy array if it isn't already."""
         if np.issubdtype(type(value), np.number):
-            value *= np.ones(len(self._site_data))
+            value *= np.ones(len(self.analysis_gids), dtype=np.float32)
 
         if not isinstance(value, np.ndarray):
             msg = ('NRWAL key "{}" returned bad type of "{}", needs to be '

--- a/reV/nrwal/nrwal.py
+++ b/reV/nrwal/nrwal.py
@@ -588,7 +588,6 @@ class RevNrwal:
                         .format(i + 1, len(self._nrwal_configs), cid,
                                 output_mask.sum(), len(output_mask)))
 
-#            breakpoint()
             nrwal_out = nrwal_config.eval(inputs=self._nrwal_inputs)
 
             # pylint: disable=C0201

--- a/reV/nrwal/nrwal.py
+++ b/reV/nrwal/nrwal.py
@@ -509,6 +509,8 @@ class RevNrwal:
             gids.
         """
         value = nrwal_out[name]
+        value = self._value_to_array(value, name)
+
         if len(value.shape) == 1:
             self._out[name][output_mask] = value[output_mask]
 
@@ -561,6 +563,11 @@ class RevNrwal:
             assert not any(value.variables), msg
             value = value.eval()
 
+        value = self._value_to_array(value, name)
+        self._out[name][output_mask] = value[output_mask]
+
+    def _value_to_array(self, value, name):
+        """Turn the input into numpy array if it isn't already."""
         if np.issubdtype(type(value), np.number):
             value *= np.ones(len(self._site_data))
 
@@ -569,8 +576,7 @@ class RevNrwal:
                    'numeric or an output array.'.format(name, type(value)))
             logger.error(msg)
             raise TypeError(msg)
-
-        self._out[name][output_mask] = value[output_mask]
+        return value
 
     def run_nrwal(self):
         """Run analysis via the NRWAL analysis library"""

--- a/tests/data/nrwal/nrwal_offshore.yaml
+++ b/tests/data/nrwal/nrwal_offshore.yaml
@@ -35,6 +35,10 @@ tax_rate:
 gcf:
   cf_mean_raw
 
+# Scale lease price
+lease_price_mil:
+  lease_price / 1000000
+
 # CapEx Equations
 cost_reductions:
   osw_2019::cost_reductions::fixed

--- a/tests/test_nrwal.py
+++ b/tests/test_nrwal.py
@@ -197,4 +197,4 @@ def execute_pytest(capture='all', flags='-rapP'):
 
 
 if __name__ == '__main__':
-    test_nrwal_constant_eq_output_request()
+    execute_pytest()


### PR DESCRIPTION
The issue:
Currently, an implicit assumption is made that when a user asks for a "calculation" output from NRWAL, it will be in the form of an array corresponding to each site. This is likely true for most cases, but it breaks in some edge cases. For example, suppose the user has a lease price input in their config file. Suppose they also want this value scaled to  millions of dollars, so they add a `lease_price_mil: lease_price / 1000000` calculation. If the user wants to request this value as an output (e.g. for debugging purposes), rev-NRWAL assumes it comes in the form of an array, where in reality the output is just a float.

The solution:
Before saving any NRWAL calculation output, single values are cast to numpy arrays. Implemented in this PR.