### PR TITLE
Pp/multi year losses seed

### DIFF
--- a/reV/SAM/generation.py
+++ b/reV/SAM/generation.py
@@ -96,7 +96,7 @@ class AbstractSamGeneration(RevPySam, ScheduledLossesMixin, ABC):
             self.check_resource_data(resource)
             self.set_resource_data(resource, meta)
 
-        self.add_scheduled_losses()
+        self.add_scheduled_losses(resource)
 
     @classmethod
     def _get_res(cls, res_df, output_request):

--- a/reV/SAM/generation.py
+++ b/reV/SAM/generation.py
@@ -1220,6 +1220,7 @@ class WindPower(AbstractSamWind):
         return DefaultWindPower.default()
 
 
+# pylint: disable=too-many-ancestors
 class WindPowerPD(WindPower):
     """WindPower analysis with wind speed/direction joint probabilty
     distrubtion input"""

--- a/reV/generation/base.py
+++ b/reV/generation/base.py
@@ -832,13 +832,16 @@ class BaseGen(ABC):
                 data_shape = (n_sites, )
 
         elif dset in self.project_points.all_sam_input_keys:
-            data_shape = (n_sites, )
             data = list(self.project_points.sam_inputs.values())[0][dset]
-            if isinstance(data, (list, tuple, np.ndarray, str)):
+            if isinstance(data, (list, tuple, np.ndarray)):
+                data_shape = (*np.array(data).shape, n_sites)
+            elif isinstance(data, str):
                 msg = ('Cannot pass through non-scalar SAM input key "{}" '
                        'as an output_request!'.format(dset))
                 logger.error(msg)
                 raise ExecutionError(msg)
+            else:
+                data_shape = (n_sites, )
 
         else:
             if self._sam_obj_default is None:

--- a/reV/generation/cli_gen.py
+++ b/reV/generation/cli_gen.py
@@ -120,6 +120,7 @@ def from_config(ctx, config_file, verbose):
 
 def submit_from_config(ctx, name, year, config, i, verbose=False):
     """Function to submit one year from a config file.
+
     Parameters
     ----------
     ctx : cli.ctx
@@ -192,12 +193,14 @@ def submit_from_config(ctx, name, year, config, i, verbose=False):
 
 def make_fout(name, year):
     """Make an appropriate file output from name and year.
+
     Parameters
     ----------
     name : str
         Job name.
     year : int | str
         Analysis year.
+
     Returns
     -------
     fout : str
@@ -318,10 +321,12 @@ def direct(ctx, tech, sam_files, res_file, out_fpath, points, lat_lon_fpath,
 def _parse_points(ctx):
     """
     Parse project points from CLI inputs
+
     Parameters
     ----------
     ctx : dict
         CLI context object
+
     Returns
     -------
     points : slice | list | string | ProjectPoints
@@ -454,6 +459,7 @@ def local(ctx, max_workers, timeout, points_range, verbose):
 
 def get_node_pc(points, sam_files, tech, res_file, nodes):
     """Get a PointsControl object to be send to HPC nodes.
+
     Parameters
     ----------
     points : slice | str | list | tuple
@@ -471,6 +477,7 @@ def get_node_pc(points, sam_files, tech, res_file, nodes):
         points slice stop is None.
     nodes : int
         Number of nodes that the PointsControl object is being split to.
+
     Returns
     -------
     pc : reV.config.project_points.PointsControl
@@ -490,6 +497,7 @@ def get_node_pc(points, sam_files, tech, res_file, nodes):
 
 def get_node_name_fout(name, fout, i, pc, hpc='slurm'):
     """Make a node name and fout unique to the run name, year, and node number.
+
     Parameters
     ----------
     name : str
@@ -503,6 +511,7 @@ def get_node_name_fout(name, fout, i, pc, hpc='slurm'):
         A PointsControl instance that i is enumerated from.
     hpc : str
         HPC job submission tool name (e.g. slurm or pbs). Affects job name.
+
     Returns
     -------
     node_name : str
@@ -543,6 +552,7 @@ def get_node_cmd(name, tech, sam_files, res_file, out_fpath,
                  site_data=None, mem_util_lim=0.4, timeout=1800,
                  curtailment=None, gid_map=None, verbose=False):
     """Make a reV geneneration direct-local CLI call string.
+
     Parameters
     ----------
     name : str
@@ -589,6 +599,7 @@ def get_node_cmd(name, tech, sam_files, res_file, out_fpath,
         gid and gid_map columns or None.
     verbose : bool
         Flag to turn on debug logging. Default is False.
+
     Returns
     -------
     cmd : str

--- a/reV/losses/scheduled.py
+++ b/reV/losses/scheduled.py
@@ -607,4 +607,4 @@ class ScheduledLossesMixin:
         except (AttributeError, TypeError):
             pass
 
-        return 0 + base_seed
+        return base_seed

--- a/reV/losses/scheduled.py
+++ b/reV/losses/scheduled.py
@@ -577,7 +577,7 @@ class ScheduledLossesMixin:
             outage_specs = json.loads(outage_specs)
 
         outages = [Outage(spec) for spec in outage_specs]
-        self.__year_seed = resource.index.year
+        self.__year_seed = int(resource.index.year.values[0])
         self.__user_input_seed = self.sam_sys_inputs.pop(
             self.OUTAGE_SEED_CONFIG_KEY, 0)
         return outages

--- a/tests/test_losses_scheduled.py
+++ b/tests/test_losses_scheduled.py
@@ -790,8 +790,8 @@ def test_outage_class_allow_outage_overlap(basic_outage_dict):
     (PV_SAM_FILE, TESTDATADIR + '/nsrdb/ri_100_nsrdb_{}.h5', 'pvwattsv5'),
     (PV_SAM_FILE, TESTDATADIR + '/nsrdb/ri_100_nsrdb_{}.h5', 'pvwattsv7')
 ])
-def test_gen_from_config(runner, files):
-    """Gen PV CF profiles with write to disk and compare against rev1."""
+def test_scheduled_outages_multi_year(runner, files):
+    """Test that scheduled outages are different year to year. """
     sam_file, res_file, tech = files
     with open(sam_file, 'r') as fh:
         sam_config = json.load(fh)

--- a/tests/test_losses_scheduled.py
+++ b/tests/test_losses_scheduled.py
@@ -512,7 +512,8 @@ def test_scheduled_losses_mixin_class_add_scheduled_losses(outages):
 
     mixin = ScheduledLossesMixin()
     mixin.sam_sys_inputs = {mixin.OUTAGE_CONFIG_KEY: outages}
-    mixin.add_scheduled_losses()
+    sample_df_with_dt = pd.DataFrame(index=pd.to_datetime(["2020-01-01"]))
+    mixin.add_scheduled_losses(sample_df_with_dt)
 
     assert mixin.OUTAGE_CONFIG_KEY not in mixin.sam_sys_inputs
     assert 'hourly' in mixin.sam_sys_inputs
@@ -523,7 +524,8 @@ def test_scheduled_losses_mixin_class_no_losses_input():
 
     mixin = ScheduledLossesMixin()
     mixin.sam_sys_inputs = {}
-    mixin.add_scheduled_losses()
+    sample_df_with_dt = pd.DataFrame(index=pd.to_datetime(["2020-01-01"]))
+    mixin.add_scheduled_losses(sample_df_with_dt)
 
     assert mixin.OUTAGE_CONFIG_KEY not in mixin.sam_sys_inputs
     assert 'hourly' not in mixin.sam_sys_inputs

--- a/tests/test_losses_scheduled.py
+++ b/tests/test_losses_scheduled.py
@@ -8,21 +8,31 @@ Created on Mon Apr 18 12:52:16 2021
 """
 
 import os
+from re import L
 import pytest
 import tempfile
 import json
 import random
 import copy
+import glob
+import traceback
 
 import numpy as np
 import pandas as pd
+from click.testing import CliRunner
 
 from reV import TESTDATADIR
 from reV.generation.generation import Gen
+from reV.config.sam_analysis_configs import GenConfig
 from reV.utilities.exceptions import reVLossesValueError, reVLossesWarning
 from reV.losses.utils import hourly_indices_for_months
 from reV.losses.scheduled import (Outage, OutageScheduler,
                                   SingleOutageScheduler, ScheduledLossesMixin)
+from reV.cli import main
+from reV.handlers.outputs import Outputs
+
+from rex.utilities.utilities import safe_json_load
+from rex.utilities.loggers import LOGGERS
 
 
 REV_POINTS = list(range(3))
@@ -113,6 +123,12 @@ def so_scheduler(basic_outage_dict):
     outage = Outage(basic_outage_dict)
     scheduler = OutageScheduler([])
     return SingleOutageScheduler(outage, scheduler)
+
+
+@pytest.fixture(scope="module")
+def runner():
+    """Cli runner."""
+    return CliRunner()
 
 
 @pytest.mark.parametrize('generic_losses', [0, 0.2])
@@ -769,6 +785,76 @@ def test_outage_class_allow_outage_overlap(basic_outage_dict):
     assert Outage(basic_outage_dict).allow_outage_overlap
     basic_outage_dict['allow_outage_overlap'] = False
     assert not Outage(basic_outage_dict).allow_outage_overlap
+
+
+@pytest.mark.parametrize('files', [
+    (WIND_SAM_FILE, TESTDATADIR + '/wtk/ri_100_wtk_{}.h5', 'windpower'),
+    (PV_SAM_FILE, TESTDATADIR + '/nsrdb/ri_100_nsrdb_{}.h5', 'pvwattsv5'),
+    (PV_SAM_FILE, TESTDATADIR + '/nsrdb/ri_100_nsrdb_{}.h5', 'pvwattsv7')
+])
+def test_gen_from_config(runner, files):
+    """Gen PV CF profiles with write to disk and compare against rev1."""
+    sam_file, res_file, tech = files
+    with open(sam_file, 'r') as fh:
+        sam_config = json.load(fh)
+
+    outages = NOMINAL_OUTAGES[0]
+    sam_config['hourly'] = [0] * 8760
+    sam_config[ScheduledLossesMixin.OUTAGE_CONFIG_KEY] = outages
+    sam_config.pop('wind_farm_losses_percent', None)
+
+    with tempfile.TemporaryDirectory() as td:
+        sam_fp = os.path.join(td, 'gen.json')
+        if 'pv' in tech:
+            config_file_path = 'local_pv.json'
+            project_points = os.path.join(TESTDATADIR, 'config',
+                                          "project_points_10.csv")
+
+            sam_config['losses'] = 0
+            with open(sam_fp, 'w+') as fh:
+                fh.write(json.dumps(sam_config))
+            sam_files = {"sam_gen_pv_1": sam_fp}
+        else:
+            config_file_path = 'local_wind.json'
+            project_points = os.path.join(TESTDATADIR, 'config',
+                                          "wtk_pp_2012_10.csv")
+            sam_config['turb_generic_loss'] = 0
+
+            with open(sam_fp, 'w+') as fh:
+                fh.write(json.dumps(sam_config))
+            sam_files = {"wind0": sam_fp}
+
+        config_file_path = 'config/{}'.format(config_file_path)
+        config = os.path.join(TESTDATADIR, config_file_path).replace('\\', '/')
+        config = safe_json_load(config)
+        config['project_points'] = project_points
+        config['resource_file'] = res_file
+        config['sam_files'] = sam_files
+        config['log_directory'] = td
+        config['output_request'] = config['output_request'] + ['hourly']
+        config['analysis_years'] = ['2012', '2013']
+
+        config_path = os.path.join(td, 'config.json')
+        with open(config_path, 'w') as f:
+            json.dump(config, f)
+
+        result = runner.invoke(main, ['-c', config_path, 'generation'])
+        LOGGERS.clear()
+
+        msg = ('Failed with error {}'
+               .format(traceback.print_exception(*result.exc_info)))
+        assert result.exit_code == 0, msg
+
+        scheduled_outages = []
+        for file in glob.glob(os.path.join(td, '*.h5')):
+            with Outputs(file, 'r') as out:
+                scheduled_outages.append(out['hourly'])
+
+        outages_2012, outages_2013 = scheduled_outages
+        for o1, o2 in zip(outages_2012.T, outages_2013.T):
+            assert len(o1) == 8760
+            assert len(o2) == 8760
+            assert not np.allclose(o1, o2)
 
 
 def test_outage_class_name(basic_outage_dict):

--- a/tests/test_losses_scheduled.py
+++ b/tests/test_losses_scheduled.py
@@ -8,7 +8,6 @@ Created on Mon Apr 18 12:52:16 2021
 """
 
 import os
-from re import L
 import pytest
 import tempfile
 import json
@@ -23,7 +22,6 @@ from click.testing import CliRunner
 
 from reV import TESTDATADIR
 from reV.generation.generation import Gen
-from reV.config.sam_analysis_configs import GenConfig
 from reV.utilities.exceptions import reVLossesValueError, reVLossesWarning
 from reV.losses.utils import hourly_indices_for_months
 from reV.losses.scheduled import (Outage, OutageScheduler,
@@ -850,6 +848,7 @@ def test_gen_from_config(runner, files):
             with Outputs(file, 'r') as out:
                 scheduled_outages.append(out['hourly'])
 
+        # pylint: disable=unbalanced-tuple-unpacking
         outages_2012, outages_2013 = scheduled_outages
         for o1, o2 in zip(outages_2012.T, outages_2013.T):
             assert len(o1) == 8760


### PR DESCRIPTION
Generation cli `from_config` now seeds the outage losses so that a unique set of outages is generated for each year when running multi-year reV generation