### PR TITLE
PySAM3 integration

### DIFF
--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -9,8 +9,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9]
+        python-version: ['3.10']
         include:
+          - os: ubuntu-latest
+            python-version: 3.9
           - os: ubuntu-latest
             python-version: 3.8
           - os: ubuntu-latest

--- a/reV/SAM/__init__.py
+++ b/reV/SAM/__init__.py
@@ -3,5 +3,6 @@
 reV-SAM interface module
 """
 from .econ import LCOE, SingleOwner
-from .generation import PvWattsv5, PvWattsv7, PvSamv1, TcsMoltenSalt, WindPower
+from .generation import (PvWattsv5, PvWattsv7, PvWattsv8, PvSamv1,
+                         TcsMoltenSalt, WindPower)
 from .windbos import WindBos

--- a/reV/SAM/defaults.py
+++ b/reV/SAM/defaults.py
@@ -4,7 +4,7 @@ import json
 import os
 import pandas as pd
 import PySAM.Pvwattsv5 as PySamPV5
-import PySAM.Pvwattsv7 as PySamPV7
+import PySAM.Pvwattsv8 as PySamPV8
 import PySAM.Pvsamv1 as PySamDetailedPV
 import PySAM.Windpower as PySamWindPower
 import PySAM.TcsmoltenSalt as PySamCSP
@@ -45,15 +45,15 @@ class DefaultPvWattsv5:
         return obj
 
 
-class DefaultPvWattsv7:
+class DefaultPvWattsv8:
     """class for default PVWattsv7"""
 
     @staticmethod
     def default():
-        """Get the default PySAM pvwattsv7 object"""
+        """Get the default PySAM pvwattsv8 object"""
         res_file = os.path.join(DEFAULTSDIR,
                                 'USA AZ Phoenix Sky Harbor Intl Ap (TMY3).csv')
-        obj = PySamPV7.default('PVWattsNone')
+        obj = PySamPV8.default('PVWattsNone')
         obj.SolarResource.solar_resource_file = res_file
         obj.execute()
 

--- a/reV/SAM/generation.py
+++ b/reV/SAM/generation.py
@@ -13,6 +13,7 @@ import pandas as pd
 from warnings import warn
 import PySAM.Pvwattsv5 as PySamPv5
 import PySAM.Pvwattsv7 as PySamPv7
+import PySAM.Pvwattsv8 as PySamPv8
 import PySAM.Pvsamv1 as PySamDetailedPv
 import PySAM.Windpower as PySamWindPower
 import PySAM.TcsmoltenSalt as PySamCSP
@@ -22,7 +23,7 @@ import PySAM.LinearFresnelDsgIph as PySamLds
 import PySAM.MhkWave as PySamMhkWave
 
 from reV.SAM.defaults import (DefaultPvWattsv5,
-                              DefaultPvWattsv7,
+                              DefaultPvWattsv8,
                               DefaultPvSamv1,
                               DefaultWindPower,
                               DefaultTcsMoltenSalt,
@@ -831,7 +832,24 @@ class PvWattsv7(AbstractSamPv):
         -------
         PySAM.Pvwattsv7
         """
-        return DefaultPvWattsv7.default()
+        raise NotImplementedError("Pvwattsv7 default file no longer exists!")
+
+
+class PvWattsv8(AbstractSamPv):
+    """Photovoltaic (PV) generation with pvwattsv8.
+    """
+    MODULE = 'pvwattsv8'
+    PYSAM = PySamPv8
+
+    @staticmethod
+    def default():
+        """Get the executed default pysam PVWATTSV8 object.
+
+        Returns
+        -------
+        PySAM.Pvwattsv8
+        """
+        return DefaultPvWattsv8.default()
 
 
 class PvSamv1(AbstractSamPv):

--- a/reV/generation/generation.py
+++ b/reV/generation/generation.py
@@ -14,6 +14,7 @@ from reV.generation.base import BaseGen
 from reV.utilities.exceptions import ProjectPointsValueError, InputError
 from reV.SAM.generation import (PvWattsv5,
                                 PvWattsv7,
+                                PvWattsv8,
                                 PvSamv1,
                                 TcsMoltenSalt,
                                 WindPower,
@@ -91,6 +92,7 @@ class Gen(BaseGen):
     # Mapping of reV technology strings to SAM generation objects
     OPTIONS = {'pvwattsv5': PvWattsv5,
                'pvwattsv7': PvWattsv7,
+               'pvwattsv8': PvWattsv8,
                'pvsamv1': PvSamv1,
                'tcsmoltensalt': TcsMoltenSalt,
                'solarwaterheat': SolarWaterHeat,

--- a/reV/supply_curve/sc_aggregation.py
+++ b/reV/supply_curve/sc_aggregation.py
@@ -570,7 +570,11 @@ class SupplyCurveAggregation(AbstractAggregation):
                                      .format(v['method'], methods))
                 if 'fpath' in v:
                     with ExclusionLayers(v['fpath']) as f:
-                        if any(f.shape != shape_base):
+                        try:
+                            mismatched_shapes = any(f.shape != shape_base)
+                        except TypeError:
+                            mismatched_shapes = f.shape != shape_base
+                        if mismatched_shapes:
                             msg = ('Data shape of data layer "{}" is {}, '
                                    'which does not match the baseline '
                                    'exclusions shape {}.'

--- a/reV/version.py
+++ b/reV/version.py
@@ -2,4 +2,4 @@
 reV Version number
 """
 
-__version__ = "0.6.6"
+__version__ = "0.7.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 NREL-NRWAL>=0.0.7
 NREL-PySAM>=3.0.0
-NREL-rex>=0.2.75
+NREL-rex>=0.2.76
 packaging>=20.3
 plotly>=4.7.1
 plotting>=0.0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 NREL-NRWAL>=0.0.7
-NREL-PySAM>=2.2.4,<3.0.0
-NREL-rex>=0.2.72
+NREL-PySAM>=3.0.0
+NREL-rex>=0.2.75
 packaging>=20.3
 plotly>=4.7.1
 plotting>=0.0.6

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     test_suite="tests",
     install_requires=install_requires,

--- a/tests/data/SAM/i_csp_tcsmolten_salt.json
+++ b/tests/data/SAM/i_csp_tcsmolten_salt.json
@@ -44982,7 +44982,7 @@
   "pc_config": 0,
   "piping_length_const": 0,
   "piping_length_mult": 2.5999999046325684,
-  "piping_loss": 10200,
+  "piping_loss_coefficient": 35,
   "plant_spec_cost": 1100,
   "ppa_escalation": 1,
   "ppa_multiplier_model": 0,

--- a/tests/data/SAM/i_singleowner_windbos.json
+++ b/tests/data/SAM/i_singleowner_windbos.json
@@ -9632,6 +9632,7 @@
   "ppa_price_input": [
     0.03999999910593033
   ],
+  "en_electricity_rates": 1,
   "ppa_soln_mode": 0,
   "profit_margin": 5.0,
   "prop_tax_assessed_decline": 0,

--- a/tests/data/SAM/wind_single_owner.json
+++ b/tests/data/SAM/wind_single_owner.json
@@ -9617,6 +9617,7 @@
   "ppa_price_input": [
     0.029999999329447746
   ],
+  "en_electricity_rates": 1,
   "ppa_soln_mode": 0,
   "prop_tax_assessed_decline": 0,
   "prop_tax_cost_assessed_percent": 0,

--- a/tests/test_econ_single_owner.py
+++ b/tests/test_econ_single_owner.py
@@ -55,8 +55,6 @@ def test_single_owner():
         result = np.allclose(v, OUT_BASELINE[k], rtol=RTOL, atol=ATOL)
         assert result, msg
 
-    return obj.out
-
 
 def execute_pytest(capture='all', flags='-rapP'):
     """Execute module as pytest with detailed summary report.

--- a/tests/test_gen_linear.py
+++ b/tests/test_gen_linear.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=all
 """
 PyTest file for linear Fresnel
-This is intended to be run with PySAM 1.2.1
 
 Created on 2/6/2020
 @author: Mike Bannister
@@ -10,7 +8,6 @@ Created on 2/6/2020
 import os
 import pytest
 import numpy as np
-import json
 
 from reV.generation.generation import Gen
 from reV import TESTDATADIR
@@ -18,7 +15,7 @@ from rex import Resource
 
 BASELINE = os.path.join(TESTDATADIR, 'gen_out', 'gen_ri_linear_2012.h5')
 RTOL = 0.01
-ATOL = 0
+ATOL = 0.05  # Increased from 0 -> 0.05 when upgrading to PySAM 3+
 
 
 def test_gen_linear():

--- a/tests/test_gen_pv.py
+++ b/tests/test_gen_pv.py
@@ -278,7 +278,7 @@ def test_southern_hemisphere():
 def test_pvwattsv7_baseline():
     """Test reV pvwattsv7 generation against baseline data"""
 
-    baseline_cf_mean = np.array([151, 151, 157]) / 1000
+    baseline_cf_mean = np.array([0.1516, 0.1517, 0.1573])
 
     year = 2012
     rev2_points = slice(0, 3)
@@ -290,8 +290,7 @@ def test_pvwattsv7_baseline():
 
     # run reV 2.0 generation
     gen = Gen.reV_run('pvwattsv7', rev2_points, sam_files, res_file,
-                      max_workers=1,
-                      sites_per_worker=1, out_fpath=None,
+                      max_workers=1, sites_per_worker=1, out_fpath=None,
                       output_request=output_request)
 
     msg = ('PVWattsv7 cf_mean results {} did not match baseline: {}'
@@ -441,7 +440,7 @@ def test_clipping():
 def test_detailed_pv_baseline():
     """Test the detailed pv module against baseline values that are similar to
     the pvwattsv7 cf mean values"""
-    baseline_cf_mean = np.array([0.1594, 0.1595, 0.1650])
+    baseline_cf_mean = np.array([0.1623, 0.1624, 0.1680])
 
     year = 2012
     rev2_points = slice(0, 3)
@@ -469,7 +468,7 @@ def test_detailed_pv_baseline():
 
 def test_detailed_pv_bifacial():
     """Test the detailed pv module with bifacial configs"""
-    baseline_cf_mean = np.array([0.17193589, 0.17201012, 0.17734073])
+    baseline_cf_mean = np.array([0.1745, 0.17455, 0.1799])
 
     year = 2012
     rev2_points = slice(0, 3)

--- a/tests/test_sam.py
+++ b/tests/test_sam.py
@@ -10,9 +10,9 @@ import numpy as np
 import pandas as pd
 import warnings
 
-from reV.SAM.defaults import (DefaultPvWattsv5, DefaultPvWattsv7,
+from reV.SAM.defaults import (DefaultPvWattsv5, DefaultPvWattsv8,
                               DefaultWindPower)
-from reV.SAM.generation import PvWattsv5, PvWattsv7
+from reV.SAM.generation import PvWattsv5, PvWattsv7, PvWattsv8
 from reV import TESTDATADIR
 from reV.config.project_points import ProjectPoints
 from reV.SAM.version_checker import PySamVersionChecker
@@ -164,6 +164,8 @@ def test_nan_resource():
         _, inputs = pp[site]
         with pytest.raises(InputError):
             PvWattsv7(resource=res_df, meta=meta, sam_sys_inputs=inputs)
+        with pytest.raises(InputError):
+            PvWattsv8(resource=res_df, meta=meta, sam_sys_inputs=inputs)
 
 
 def test_default_pvwattsv5():
@@ -172,10 +174,10 @@ def test_default_pvwattsv5():
     assert round(default.Outputs.annual_energy, -1) == 6830
 
 
-def test_default_pvwattsv7():
-    """Test default pvwattsv7 execution and compare baseline annual energy"""
-    default = DefaultPvWattsv7.default()
-    assert round(default.Outputs.annual_energy, -1) == 6940
+def test_default_pvwattsv8():
+    """Test default pvwattsv8 execution and compare baseline annual energy"""
+    default = DefaultPvWattsv8.default()
+    assert round(default.Outputs.annual_energy, -1) == 11160
 
 
 def test_default_windpower():


### PR DESCRIPTION
Only minor changes to tests - mostly just a new input key here or there or a light update to baseline values.

Pvwattsv7 default is deprecated in PySAM 3+, so the default class was removed, though Pvwattsv7 is still allowed to be used (indeed, all existing tests use "pvwattsv7" as the tech). Also added Pvwattsv8 as a new tech option.

Updated support to Python 3.10 including tests.