### PR TITLE
Bespoke bug fixes

### DIFF
--- a/reV/bespoke/bespoke.py
+++ b/reV/bespoke/bespoke.py
@@ -1312,7 +1312,10 @@ class BespokeWindPlants(AbstractAggregation):
             Full filepath to an output .h5 file to save Bespoke data to. The
             parent directories will be created if they do not already exist.
         """
-
+        if not self.completed_gids:
+            logger.info('No output data found! It is likely that all '
+                        'requested points are excluded.')
+            return
         sample = self.outputs[self.completed_gids[0]]
         out_fpath = self._init_fout(out_fpath, sample)
 

--- a/reV/bespoke/bespoke.py
+++ b/reV/bespoke/bespoke.py
@@ -14,6 +14,7 @@ import psutil
 from importlib import import_module
 from numbers import Number
 from concurrent.futures import as_completed
+from warnings import warn
 
 from reV.config.project_points import ProjectPoints
 from reV.generation.generation import Gen
@@ -1313,9 +1314,12 @@ class BespokeWindPlants(AbstractAggregation):
             parent directories will be created if they do not already exist.
         """
         if not self.completed_gids:
-            logger.info('No output data found! It is likely that all '
-                        'requested points are excluded.')
+            msg = ("No output data found! It is likely that all requested "
+                   "points are excluded.")
+            logger.warn(msg)
+            warn(msg)
             return
+
         sample = self.outputs[self.completed_gids[0]]
         out_fpath = self._init_fout(out_fpath, sample)
 

--- a/reV/bespoke/bespoke.py
+++ b/reV/bespoke/bespoke.py
@@ -1316,7 +1316,7 @@ class BespokeWindPlants(AbstractAggregation):
         if not self.completed_gids:
             msg = ("No output data found! It is likely that all requested "
                    "points are excluded.")
-            logger.warn(msg)
+            logger.warning(msg)
             warn(msg)
             return
 

--- a/reV/supply_curve/exclusions.py
+++ b/reV/supply_curve/exclusions.py
@@ -345,14 +345,15 @@ class LayerMask:
         mask : ndarray
             Boolean mask of which values to include (True is include).
         """
-        mask = np.full(data.shape, True)
+        mask = np.full(data.shape, False)
         if self.min_value is not None:
-            mask = data <= self.min_value
+            mask = data < self.min_value
 
         if self.max_value is not None:
-            mask *= data >= self.max_value
+            mask |= data > self.max_value
 
-        if self._exclude_nodata and self.nodata_value is not None:
+        mask[data == self.nodata_value] = True
+        if self._exclude_nodata:
             mask = mask & (data != self.nodata_value)
 
         return mask

--- a/reV/supply_curve/points.py
+++ b/reV/supply_curve/points.py
@@ -793,14 +793,14 @@ class SupplyCurvePoint(AbstractSupplyCurvePoint):
 
         if data_layers is not None:
             for name, attrs in data_layers.items():
-
-                if 'fobj' not in attrs:
-                    with ExclusionLayers(attrs['fpath']) as f:
-                        raw = f[attrs['dset'], self.rows, self.cols]
-                        nodata = f.get_nodata_value(attrs['dset'])
+                excl_fp = attrs.get('fpath', self._excl_fpath)
+                if excl_fp != self._excl_fpath:
+                    fh = ExclusionLayers(attrs['fpath'])
                 else:
-                    raw = attrs['fobj'][attrs['dset'], self.rows, self.cols]
-                    nodata = attrs['fobj'].get_nodata_value(attrs['dset'])
+                    fh = self.exclusions.excl_h5
+
+                raw = fh[attrs['dset'], self.rows, self.cols]
+                nodata = fh.get_nodata_value(attrs['dset'])
 
                 data = raw.flatten()[self.bool_mask]
                 incl_mult = self.include_mask_flat[self.bool_mask].copy()
@@ -820,6 +820,9 @@ class SupplyCurvePoint(AbstractSupplyCurvePoint):
                 data = self._agg_data_layer_method(data, incl_mult,
                                                    attrs['method'])
                 summary[name] = data
+
+                if excl_fp != self._excl_fpath:
+                    fh.close()
 
         return summary
 

--- a/reV/supply_curve/sc_aggregation.py
+++ b/reV/supply_curve/sc_aggregation.py
@@ -97,7 +97,7 @@ class SupplyCurveAggFileHandler(AbstractAggFileHandler):
         # pre-initialize the resource meta data
         _ = self._gen.meta
 
-        self._data_layers = self._open_data_layers(data_layers)
+        self._data_layers = data_layers
         self._power_density = power_density
         self._parse_power_density()
 
@@ -143,48 +143,6 @@ class SupplyCurveAggFileHandler(AbstractAggFileHandler):
 
         return handler
 
-    def _open_data_layers(self, data_layers):
-        """Open data layer Exclusion h5 handlers.
-
-        Parameters
-        ----------
-        data_layers : None | dict
-            Aggregation data layers. Must be a dictionary keyed by data label
-            name. Each value must be another dictionary with "dset", "method",
-            and "fpath".
-
-        Returns
-        -------
-        data_layers : None | dict
-            Aggregation data layers. fobj is added to the dictionary of each
-            layer.
-        """
-
-        if data_layers is not None:
-            for name, attrs in data_layers.items():
-                data_layers[name]['fobj'] = self._excl.excl_h5
-                if 'fpath' in attrs:
-                    if attrs['fpath'] != self._excl_fpath:
-                        data_layers[name]['fobj'] = ExclusionLayers(
-                            attrs['fpath'])
-
-        return data_layers
-
-    @staticmethod
-    def _close_data_layers(data_layers):
-        """Close all data layers with exclusion h5 handlers.
-
-        Parameters
-        ----------
-        data_layers : None | dict
-            Aggregation data layers. Must have fobj exclusion handlers to close
-        """
-
-        if data_layers is not None:
-            for layer in data_layers.values():
-                if 'fobj' in layer:
-                    layer['fobj'].close()
-
     def _parse_power_density(self):
         """Parse the power density input. If file, open file handler."""
 
@@ -212,7 +170,6 @@ class SupplyCurveAggFileHandler(AbstractAggFileHandler):
         """Close all file handlers."""
         self._excl.close()
         self._gen.close()
-        self._close_data_layers(self._data_layers)
         if self._friction_layer is not None:
             self._friction_layer.close()
 

--- a/tests/test_bespoke.py
+++ b/tests/test_bespoke.py
@@ -432,8 +432,21 @@ def test_bespoke():
         res_fp = res_fp.format('*')
         # both 33 and 35 are included, 37 is fully excluded
         points = [33, 35]
+        fully_excluded_points = [37]
 
         TechMapping.run(excl_fp, RES.format(2012), dset=TM_DSET, max_workers=1)
+
+        assert not os.path.exists(out_fpath)
+        _ = BespokeWindPlants.run(excl_fp, res_fp, TM_DSET,
+                                  objective_function, cap_cost_fun,
+                                  foc_fun, voc_fun,
+                                  fully_excluded_points, SAM_CONFIGS,
+                                  ga_kwargs={'max_time': 5},
+                                  excl_dict=EXCL_DICT,
+                                  output_request=output_request,
+                                  max_workers=2,
+                                  out_fpath=out_fpath)
+        assert not os.path.exists(out_fpath)
         _ = BespokeWindPlants.run(excl_fp, res_fp, TM_DSET,
                                   objective_function, cap_cost_fun,
                                   foc_fun, voc_fun,
@@ -443,7 +456,7 @@ def test_bespoke():
                                   output_request=output_request,
                                   max_workers=2,
                                   out_fpath=out_fpath)
-
+        assert os.path.exists(out_fpath)
         with Resource(out_fpath) as f:
             meta = f.meta
             assert len(meta) <= len(points)

--- a/tests/test_bespoke.py
+++ b/tests/test_bespoke.py
@@ -386,7 +386,41 @@ def test_extra_outputs(gid=33):
                                  ga_kwargs={'max_time': 5},
                                  excl_dict=EXCL_DICT,
                                  output_request=output_request,
-                                 data_layers=DATA_LAYERS,
+                                 data_layers=copy.deepcopy(DATA_LAYERS),
+                                 )
+
+        out = bsp.run_plant_optimization()
+        out = bsp.run_wind_plant_ts()
+        bsp.agg_data_layers()
+
+        assert 'lcoe_fcr-2012' in out
+        assert 'lcoe_fcr-2013' in out
+        assert 'lcoe_fcr-means' in out
+
+        assert 'capacity' in bsp.meta
+        assert 'mean_cf' in bsp.meta
+        assert 'mean_lcoe' in bsp.meta
+
+        assert 'pct_slope' in bsp.meta
+        assert 'reeds_region' in bsp.meta
+        assert 'padus' in bsp.meta
+
+        out = None
+        data_layers = copy.deepcopy(DATA_LAYERS)
+        for layer in data_layers:
+            data_layers[layer].pop('fpath', None)
+
+        for layer in data_layers:
+            assert 'fpath' not in data_layers[layer]
+
+        bsp = BespokeSinglePlant(gid, excl_fp, res_fp, TM_DSET,
+                                 sam_sys_inputs,
+                                 objective_function, cap_cost_fun,
+                                 foc_fun, voc_fun,
+                                 ga_kwargs={'max_time': 5},
+                                 excl_dict=EXCL_DICT,
+                                 output_request=output_request,
+                                 data_layers=data_layers,
                                  )
 
         out = bsp.run_plant_optimization()

--- a/tests/test_qa_qc_summary.py
+++ b/tests/test_qa_qc_summary.py
@@ -37,7 +37,7 @@ def test_summarize(dataset):
         test = summary.summarize_dset(
             dataset, process_size=None, max_workers=1)
 
-    assert_frame_equal(test, baseline, check_dtype=False)
+    assert_frame_equal(test, baseline, check_dtype=False, atol=1e-5)
 
 
 def test_sc_summarize():

--- a/tests/test_supply_curve_exclusions.py
+++ b/tests/test_supply_curve_exclusions.py
@@ -187,6 +187,36 @@ def test_inclusion_mask(scenario):
     assert np.allclose(truth, dict_test)
 
 
+def test_exclude_range():
+    """
+    Test creation of inclusion mask with "exclude_range" key
+    """
+    excl_h5 = os.path.join(TESTDATADIR, 'ri_exclusions', 'ri_exclusions.h5')
+    with ExclusionLayers(excl_h5) as excl:
+        # unique vals are 1, 2, and 255, where 255 == nodata value
+        padus_data = excl.get_layer_values("ri_padus")
+
+    excl_dict = {'ri_padus': {'exclude_range': (None, 1),
+                              'exclude_nodata': False}}
+    dict_test = ExclusionMaskFromDict.run(excl_h5, layers_dict=excl_dict)
+    assert dict_test.sum() == (padus_data > 1).sum()
+
+    excl_dict = {'ri_padus': {'exclude_range': (5, None),
+                              'exclude_nodata': False}}
+    dict_test = ExclusionMaskFromDict.run(excl_h5, layers_dict=excl_dict)
+    assert dict_test.sum() == dict_test.size
+
+    excl_dict = {'ri_padus': {'exclude_range': (1, 2),
+                              'exclude_nodata': False}}
+    dict_test = ExclusionMaskFromDict.run(excl_h5, layers_dict=excl_dict)
+    assert dict_test.sum() == (padus_data > 2).sum()
+
+    excl_dict = {'ri_padus': {'exclude_range': (1, 2),
+                              'exclude_nodata': True}}
+    dict_test = ExclusionMaskFromDict.run(excl_h5, layers_dict=excl_dict)
+    assert dict_test.sum() == 0
+
+
 def test_bad_layer():
     """
     Test creation of inclusion mask

--- a/tests/test_supply_curve_exclusions.py
+++ b/tests/test_supply_curve_exclusions.py
@@ -416,7 +416,7 @@ def test_legacy_kwargs():
 
     excl_dict = {'ri_padus': {'inclusion_values': [1, ], 'weight': 0.25,
                               'exclude_nodata': False}}
-    with pytest.warns() as record:
+    with pytest.warns(UserWarning) as record:
         with ExclusionMaskFromDict(excl_h5, layers_dict=excl_dict) as f:
             assert (f.mask).any()
         assert len(record) == 1
@@ -424,7 +424,7 @@ def test_legacy_kwargs():
 
     excl_dict = {'ri_padus': {'inclusion_range': (1, None), 'weight': 0.25,
                               'exclude_nodata': False}}
-    with pytest.warns() as record:
+    with pytest.warns(UserWarning) as record:
         with ExclusionMaskFromDict(excl_h5, layers_dict=excl_dict) as f:
             assert (f.mask).any()
         assert len(record) == 1


### PR DESCRIPTION
Fix for several bugs:
- Bespoke run no longer crashes if all input points are fully excluded. 
- Previous `exclude_range` logic was looking for values that are both less than the min value and larger than the max value simultaneously. This was causing all layers using `exclude_range` to be fully excluded every time. 
- Bespoke no longer crashes if data layers do not specify `fpath`. This now matches reV-gen behavior, and was accomplished by moving the file opening logic into the points class

All logic changes include tests.