### PR TITLE
Bespoke site data to sys inputs

### DIFF
--- a/.github/workflows/pr_revx_tests.yml
+++ b/.github/workflows/pr_revx_tests.yml
@@ -33,7 +33,8 @@ jobs:
       working-directory: ./reVX
       shell: bash -l {0}
       run: |
-        conda install rtree geopandas
+        conda install rtree pytest
+        pip install geopandas
         pip install --upgrade --force-reinstall shapely~=1.8
         pip install -e .
         pip install HOPP
@@ -41,5 +42,4 @@ jobs:
       working-directory: ./reVX
       shell: bash -l {0}
       run: |
-        conda install pytest
         pytest -v --disable-warnings

--- a/reV/bespoke/bespoke.py
+++ b/reV/bespoke/bespoke.py
@@ -372,21 +372,12 @@ class BespokeSinglePlant:
         -------
         dict
         """
+        config = copy.deepcopy(self._sam_sys_inputs)
         if self._wind_plant_pd is None:
-            return copy.deepcopy(self._sam_sys_inputs)
-        else:
-            config = copy.deepcopy(self._wind_plant_pd.sam_sys_inputs)
-            config['wind_turbine_powercurve_powerout'] = \
-                self._sam_sys_inputs['wind_turbine_powercurve_powerout']
-
-            keys_to_copy = [PowerCurveLossesMixin.POWER_CURVE_CONFIG_KEY,
-                            ScheduledLossesMixin.OUTAGE_CONFIG_KEY,
-                            'hourly']
-            for key in keys_to_copy:
-                if key in self._sam_sys_inputs:
-                    config[key] = self._sam_sys_inputs[key]
-
             return config
+
+        config.update(self._wind_plant_pd.sam_sys_inputs)
+        return config
 
     @property
     def sc_point(self):
@@ -928,12 +919,23 @@ class BespokeWindPlants(AbstractAggregation):
             Dataset name in the techmap file containing the
             exclusions-to-resource mapping data.
         points : int | slice | list | str | PointsControl | None
-            Slice or list specifying project points, string pointing to a
-            project points csv, or a fully instantiated PointsControl object.
-            Can also be a single site integer value. Points csv should have
-            'gid' and 'config' column, the config maps to the sam_configs dict
-            keys. If this is None, all available reV supply curve points are
-            included (or sliced by points_range).
+            Slice or list specifying project points, string pointing to
+            a project points csv, or a fully instantiated PointsControl
+            object. Can also be a single site integer value. Points csv
+            should have 'gid' and 'config' column, the config maps to
+            the sam_configs dict keys. CSV file can also have any of the
+            SAM system config keys as columns. Values of these columns
+            are treated as site-specific inputs for each gid. CSV file
+            can also have these extra columns:
+                - capital_cost_multiplier
+                - fixed_operating_cost_multiplier
+                - variable_operating_cost_multiplier
+            These inputs are treated as multipliers to be applied to
+            the respective cost curves (`capital_cost_function`,
+            `fixed_operating_cost_function`, and
+            `variable_operating_cost_function`) both during and after
+            the optimization. If this is None, all available reV supply
+            curve points are included (or sliced by points_range).
         sam_configs : dict | str | SAMConfig
             SAM input configuration ID(s) and file path(s). Keys are the SAM
             config ID(s) which map to the config column in the project points

--- a/reV/bespoke/bespoke.py
+++ b/reV/bespoke/bespoke.py
@@ -25,7 +25,6 @@ from reV.handlers.exclusions import ExclusionLayers
 from reV.supply_curve.extent import SupplyCurveExtent
 from reV.supply_curve.points import AggregationSupplyCurvePoint as AggSCPoint
 from reV.supply_curve.aggregation import AbstractAggregation, AggFileHandler
-from reV.losses import PowerCurveLossesMixin, ScheduledLossesMixin
 from reV.utilities.exceptions import (EmptySupplyCurvePointError,
                                       FileInputError)
 from reV.utilities import log_versions

--- a/reV/bespoke/bespoke.py
+++ b/reV/bespoke/bespoke.py
@@ -1242,8 +1242,7 @@ class BespokeWindPlants(AbstractAggregation):
 
         site_sys_inputs = self._project_points[gid][1]
         site_sys_inputs.update({k: v for k, v in site_data.to_dict().items()
-                                if not isinstance(v, float)
-                                or not np.isnan(v)})
+                                if not (isinstance(v, float) and np.isnan(v))})
         return site_sys_inputs
 
     def _init_fout(self, out_fpath, sample):

--- a/reV/bespoke/place_turbines.py
+++ b/reV/bespoke/place_turbines.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=inconsistent-return-statements
 """
 place turbines for bespoke wind plants
 """
@@ -11,7 +12,35 @@ from reV.bespoke.gradient_free import GeneticAlgorithm
 from reV.utilities.exceptions import WhileLoopPackingError
 
 
-class PlaceTurbines():
+def none_until_optimized(func):
+    """Decorator that returns None until `PlaceTurbines` is optimized.
+
+    Meant for exclusive use in `PlaceTurbines` and its subclasses.
+    `PlaceTurbines` is considered optimized when its
+    `optimized_design_variables` attribute is not `None`.
+
+    Parameters
+    ----------
+    func : callable
+        A callable function that should return `None` until
+        `PlaceTurbines` is optimized.
+
+    Returns
+    -------
+    callable
+        New function that returns `None` until `PlaceTurbines` is
+        optimized.
+    """
+
+    def _func(pt):
+        """Wrapper to return `None` if `PlaceTurbines` is not optimized"""
+        if pt.optimized_design_variables is None:
+            return
+        return func(pt)
+    return _func
+
+
+class PlaceTurbines:
     """Framework for optimizing turbine locations for site specific
     exclusions, wind resources, and objective
     """
@@ -207,6 +236,13 @@ class PlaceTurbines():
         variable_operating_cost = eval(self.variable_operating_cost_function,
                                        globals(), locals())
 
+        capital_cost *= self.wind_plant.sam_sys_inputs.get(
+            'capital_cost_multiplier', 1)
+        fixed_operating_cost *= self.wind_plant.sam_sys_inputs.get(
+            'fixed_operating_cost_multiplier', 1)
+        variable_operating_cost *= self.wind_plant.sam_sys_inputs.get(
+            'variable_operating_cost_multiplier', 1)
+
         objective = eval(self.objective_function, globals(), locals())
 
         return objective
@@ -294,44 +330,34 @@ class PlaceTurbines():
         self.optimize(**kwargs)
 
     @property
+    @none_until_optimized
     def turbine_x(self):
         """This is the final optimized turbine x locations (m)"""
-        if self.optimized_design_variables is not None:
-            return self.x_locations[self.optimized_design_variables]
-        else:
-            return None
+        return self.x_locations[self.optimized_design_variables]
 
     @property
+    @none_until_optimized
     def turbine_y(self):
         """This is the final optimized turbine y locations (m)"""
-        if self.optimized_design_variables is not None:
-            return self.y_locations[self.optimized_design_variables]
-        else:
-            return None
+        return self.y_locations[self.optimized_design_variables]
 
     @property
+    @none_until_optimized
     def nturbs(self):
         """This is the final optimized number of turbines"""
-        if self.optimized_design_variables is not None:
-            return np.sum(self.optimized_design_variables)
-        else:
-            return None
+        return np.sum(self.optimized_design_variables)
 
     @property
+    @none_until_optimized
     def capacity(self):
         """This is the final optimized plant nameplate capacity (kW)"""
-        if self.optimized_design_variables is not None:
-            return self.turbine_capacity * self.nturbs
-        else:
-            return None
+        return self.turbine_capacity * self.nturbs
 
     @property
+    @none_until_optimized
     def area(self):
         """This is the area available for wind turbine placement (km2)"""
-        if self.full_polygons is not None:
-            return self.full_polygons.area
-        else:
-            return None
+        return self.full_polygons.area
 
     @property
     def fixed_charge_rate(self):
@@ -345,84 +371,81 @@ class PlaceTurbines():
         defined with the area available after removing the exclusions
         (MW/km2)"""
         if self.full_polygons is None or self.capacity is None:
-            return None
-        else:
-            if self.area != 0.0:
-                return self.capacity / self.area * 1E3
-            else:
-                return 0.0
+            return
+
+        if self.area != 0.0:
+            return self.capacity / self.area * 1E3
+
+        return 0.0
 
     @property
+    @none_until_optimized
     def aep(self):
         """This is the annual energy production of the optimized plant (kWh)"""
-        if self.optimized_design_variables is not None:
-            if self.nturbs > 0:
-                self.wind_plant["wind_farm_xCoordinates"] = self.turbine_x
-                self.wind_plant["wind_farm_yCoordinates"] = self.turbine_y
-                self.wind_plant["system_capacity"] = self.capacity
-                self.wind_plant.assign_inputs()
-                self.wind_plant.execute()
-                return self.wind_plant.annual_energy()
-            else:
-                return 0
-        else:
-            return None
+        if self.nturbs <= 0 :
+            return 0
+
+        self.wind_plant["wind_farm_xCoordinates"] = self.turbine_x
+        self.wind_plant["wind_farm_yCoordinates"] = self.turbine_y
+        self.wind_plant["system_capacity"] = self.capacity
+        self.wind_plant.assign_inputs()
+        self.wind_plant.execute()
+        return self.wind_plant.annual_energy()
 
     # pylint: disable=W0641,W0123
     @property
+    @none_until_optimized
     def capital_cost(self):
         """This is the capital cost of the optimized plant ($)"""
-        if self.optimized_design_variables is not None:
-            fixed_charge_rate = self.fixed_charge_rate
-            n_turbines = self.nturbs
-            system_capacity = self.capacity
-            aep = self.aep
-            return eval(self.capital_cost_function, globals(), locals())
-        else:
-            return None
+        fixed_charge_rate = self.fixed_charge_rate
+        n_turbines = self.nturbs
+        system_capacity = self.capacity
+        aep = self.aep
+        mult = self.wind_plant.sam_sys_inputs.get(
+            'capital_cost_multiplier', 1)
+        return eval(self.capital_cost_function, globals(), locals()) * mult
 
     # pylint: disable=W0641,W0123
     @property
+    @none_until_optimized
     def fixed_operating_cost(self):
         """This is the annual fixed operating cost of the
         optimized plant ($/year)"""
-        if self.optimized_design_variables is not None:
-            fixed_charge_rate = self.fixed_charge_rate
-            n_turbines = self.nturbs
-            system_capacity = self.capacity
-            aep = self.aep
-            return eval(self.fixed_operating_cost_function,
-                        globals(), locals())
-        else:
-            return None
+        fixed_charge_rate = self.fixed_charge_rate
+        n_turbines = self.nturbs
+        system_capacity = self.capacity
+        aep = self.aep
+        mult = self.wind_plant.sam_sys_inputs.get(
+            'fixed_operating_cost_multiplier', 1)
+        return eval(self.fixed_operating_cost_function,
+                    globals(), locals()) * mult
+
 
     # pylint: disable=W0641,W0123
     @property
+    @none_until_optimized
     def variable_operating_cost(self):
         """This is the annual variable operating cost of the
         optimized plant ($/kWh)"""
-        if self.optimized_design_variables is not None:
-            fixed_charge_rate = self.fixed_charge_rate
-            n_turbines = self.nturbs
-            system_capacity = self.capacity
-            aep = self.aep
-            return eval(self.variable_operating_cost_function,
-                        globals(), locals())
-        else:
-            return None
+        fixed_charge_rate = self.fixed_charge_rate
+        n_turbines = self.nturbs
+        system_capacity = self.capacity
+        aep = self.aep
+        mult = self.wind_plant.sam_sys_inputs.get(
+            'variable_operating_cost_multiplier', 1)
+        return eval(self.variable_operating_cost_function,
+                    globals(), locals()) * mult
 
     # pylint: disable=W0641,W0123
     @property
+    @none_until_optimized
     def objective(self):
         """This is the optimized objective function value"""
-        if self.optimized_design_variables is not None:
-            fixed_charge_rate = self.fixed_charge_rate
-            n_turbines = self.nturbs
-            system_capacity = self.capacity
-            aep = self.aep
-            capital_cost = self.capital_cost
-            fixed_operating_cost = self.fixed_operating_cost
-            variable_operating_cost = self.variable_operating_cost
-            return eval(self.objective_function, globals(), locals())
-        else:
-            return None
+        fixed_charge_rate = self.fixed_charge_rate
+        n_turbines = self.nturbs
+        system_capacity = self.capacity
+        aep = self.aep
+        capital_cost = self.capital_cost
+        fixed_operating_cost = self.fixed_operating_cost
+        variable_operating_cost = self.variable_operating_cost
+        return eval(self.objective_function, globals(), locals())

--- a/reV/bespoke/place_turbines.py
+++ b/reV/bespoke/place_turbines.py
@@ -382,7 +382,7 @@ class PlaceTurbines:
     @none_until_optimized
     def aep(self):
         """This is the annual energy production of the optimized plant (kWh)"""
-        if self.nturbs <= 0 :
+        if self.nturbs <= 0:
             return 0
 
         self.wind_plant["wind_farm_xCoordinates"] = self.turbine_x
@@ -419,7 +419,6 @@ class PlaceTurbines:
             'fixed_operating_cost_multiplier', 1)
         return eval(self.fixed_operating_cost_function,
                     globals(), locals()) * mult
-
 
     # pylint: disable=W0641,W0123
     @property

--- a/tests/test_bespoke.py
+++ b/tests/test_bespoke.py
@@ -459,7 +459,8 @@ def test_extra_outputs(gid=33):
 def test_bespoke():
     """Test bespoke optimization with multiple plants, parallel processing, and
     file output. """
-    output_request = ('system_capacity', 'cf_mean', 'cf_profile')
+    output_request = ('system_capacity', 'cf_mean', 'cf_profile',
+                      'extra_unused_data')
 
     cap_cost_fun = ('140 * system_capacity '
                     '* np.exp(-system_capacity / 1E5 * 0.1 + (1 - 0.1))')
@@ -480,8 +481,10 @@ def test_bespoke():
         res_fp = res_fp.format('*')
         # both 33 and 35 are included, 37 is fully excluded
         points = pd.DataFrame({'gid': [33, 35], 'config': ['default'] * 2,
-                               'extra_unused_data': ["not", "useful"]})
-        fully_excluded_points = [37]
+                               'extra_unused_data': [0, 42]})
+        fully_excluded_points = pd.DataFrame({'gid': [37],
+                                              'config': ['default'],
+                                              'extra_unused_data': [0]})
 
         TechMapping.run(excl_fp, RES.format(2012), dset=TM_DSET, max_workers=1)
 
@@ -516,7 +519,8 @@ def test_bespoke():
             assert 'possible_y_coords' in meta
 
             dsets_1d = ('n_turbines', 'system_capacity', 'cf_mean-2012',
-                        'annual_energy-2012', 'cf_mean-means')
+                        'annual_energy-2012', 'cf_mean-means',
+                        'extra_unused_data-2012')
             for dset in dsets_1d:
                 assert dset in list(f)
                 assert isinstance(f[dset], np.ndarray)

--- a/tests/test_bespoke.py
+++ b/tests/test_bespoke.py
@@ -465,7 +465,8 @@ def test_bespoke():
         shutil.copy(RES.format(2013), res_fp.format(2013))
         res_fp = res_fp.format('*')
         # both 33 and 35 are included, 37 is fully excluded
-        points = [33, 35]
+        points = pd.DataFrame({'gid': [33, 35], 'config': ['default'] * 2,
+                               'extra_unused_data': ["not", "useful"]})
         fully_excluded_points = [37]
 
         TechMapping.run(excl_fp, RES.format(2012), dset=TM_DSET, max_workers=1)

--- a/tests/test_bespoke.py
+++ b/tests/test_bespoke.py
@@ -924,8 +924,8 @@ def test_bespoke_run_with_scheduled_losses():
                            out_losses['hourly-2013'])
 
 
-def test_bespoke_wind_plant_with_power_curve_losses():
-    """Test bespoke ``wind_plant`` with power curve losses. """
+def test_bespoke_aep_is_zero_if_no_turbines_placed():
+    """Test that bespoke aep output is zero if no turbines placed. """
     output_request = ('system_capacity', 'cf_mean', 'cf_profile')
 
     cap_cost_fun = ('140 * system_capacity '

--- a/tests/test_bespoke.py
+++ b/tests/test_bespoke.py
@@ -81,9 +81,13 @@ def test_turbine_placement(gid=33):
         shutil.copy(RES.format(2013), res_fp.format(2013))
         res_fp = res_fp.format('*')
 
+        sam_sys_inputs = copy.deepcopy(SAM_SYS_INPUTS)
+        sam_sys_inputs['fixed_operating_cost_multiplier'] = 2
+        sam_sys_inputs['variable_operating_cost_multiplier'] = 5
+
         TechMapping.run(excl_fp, RES.format(2012), dset=TM_DSET, max_workers=1)
         bsp = BespokeSinglePlant(gid, excl_fp, res_fp, TM_DSET,
-                                 SAM_SYS_INPUTS,
+                                 sam_sys_inputs,
                                  objective_function,
                                  cap_cost_fun,
                                  foc_fun,
@@ -93,6 +97,16 @@ def test_turbine_placement(gid=33):
                                  )
 
         place_optimizer = bsp.plant_optimizer
+        assert place_optimizer.turbine_x is None
+        assert place_optimizer.turbine_y is None
+        assert place_optimizer.nturbs is None
+        assert place_optimizer.capacity is None
+        assert place_optimizer.area is None
+        assert place_optimizer.aep is None
+        assert place_optimizer.capital_cost is None
+        assert place_optimizer.fixed_operating_cost is None
+        assert place_optimizer.variable_operating_cost is None
+        assert place_optimizer.objective is None
         place_optimizer.place_turbines(max_time=5)
 
         assert place_optimizer.nturbs == len(place_optimizer.turbine_x)
@@ -120,8 +134,8 @@ def test_turbine_placement(gid=33):
         aep = place_optimizer.aep
         # pylint: disable=W0123
         capital_cost = eval(cap_cost_fun, globals(), locals())
-        fixed_operating_cost = eval(foc_fun, globals(), locals())
-        variable_operating_cost = eval(voc_fun, globals(), locals())
+        fixed_operating_cost = eval(foc_fun, globals(), locals()) * 2
+        variable_operating_cost = eval(voc_fun, globals(), locals()) * 5
         # pylint: disable=W0123
         assert place_optimizer.objective ==\
             eval(objective_function, globals(), locals())


### PR DESCRIPTION
Added ability to input site-specific SAM technology inputs via the project points csv input in Bespoke. 
Also added support for capital cost, fixed operating cost, and variable operating cost multiplier inputs, also via project points.

Also simplified some of the code (no logic changes) in the `PlaceTurbines` class. 

No new tests were necessary - changes were small enough to fit within the existing test infrastructure.