### PR TITLE
New Columns

### DIFF
--- a/reV/bespoke/bespoke.py
+++ b/reV/bespoke/bespoke.py
@@ -844,7 +844,7 @@ class BespokeSinglePlant:
         self._meta['capacity'] = self.outputs['system_capacity'] / 1e3
 
         # add required ReEDS multipliers to meta
-        baseline_cost = self.plant_optimizer.capital_cost_per_kw_at(
+        baseline_cost = self.plant_optimizer.capital_cost_per_kw(
             capacity_mw=self._baseline_cap_mw)
         self._meta['eos_mult'] = (self.plant_optimizer.capital_cost
                                   / self.plant_optimizer.capacity

--- a/reV/bespoke/bespoke.py
+++ b/reV/bespoke/bespoke.py
@@ -56,7 +56,7 @@ class BespokeSinglePlant:
                  ws_bins=(0.0, 20.0, 5.0), wd_bins=(0.0, 360.0, 45.0),
                  excl_dict=None, inclusion_mask=None, data_layers=None,
                  resolution=64, excl_area=None, exclusion_shape=None,
-                 close=True):
+                 eos_mult_baseline_cap_mw=200, close=True):
         """
         Parameters
         ----------
@@ -155,6 +155,13 @@ class BespokeSinglePlant:
         exclusion_shape : tuple
             Shape of the full exclusions extent (rows, cols). Inputing this
             will speed things up considerably.
+        eos_mult_baseline_cap_mw : int | float, optional
+            Baseline plant capacity (MW) used to calculate economies of
+            scale (EOS) multiplier from the `capital_cost_function`. EOS
+            multiplier is calculated as the $-per-kW of the wind plant
+            divided by the $-per-kW of a plant with this baseline
+            capacity. By default, `200` (MW), which aligns the baseline
+            with ATB assumptions. See here: https://tinyurl.com/y85hnu6h.
         close : bool
             Flag to close object file handlers on exit.
         """
@@ -196,6 +203,7 @@ class BespokeSinglePlant:
         self._out_req = list(output_request)
         self._ws_bins = ws_bins
         self._wd_bins = wd_bins
+        self._baseline_cap_mw = eos_mult_baseline_cap_mw
 
         self._res_df = None
         self._meta = None
@@ -834,6 +842,15 @@ class BespokeSinglePlant:
         # copy dataset outputs to meta data for supply curve table summary
         # convert SAM system capacity in kW to reV supply curve cap in MW
         self._meta['capacity'] = self.outputs['system_capacity'] / 1e3
+
+        # add required ReEDS multipliers to meta
+        baseline_cost = self.plant_optimizer.capital_cost_per_kw_at(
+            capacity_mw=self._baseline_cap_mw)
+        self._meta['eos_mult'] = (self.plant_optimizer.capital_cost
+                                  / self.plant_optimizer.capacity
+                                  / baseline_cost)
+        self._meta['reg_mult'] = (self.sam_sys_inputs
+                                  .get("capital_cost_multiplier", 1))
 
         return self.outputs
 

--- a/reV/bespoke/place_turbines.py
+++ b/reV/bespoke/place_turbines.py
@@ -329,6 +329,35 @@ class PlaceTurbines:
         self.initialize_packing()
         self.optimize(**kwargs)
 
+    def capital_cost_per_kw_at(self, capacity_mw):
+        """Capital cost function (per kW) evaluated for a given capacity.
+
+        The capacity will be adjusted to be an exact multiple of the
+        turbine rating in order to yield an integer number of
+        turbines.
+
+        Parameters
+        ----------
+        capacity_mw : float
+            The desired capacity (MW) to sample the cost curve at. Note
+            as mentioned above, the capacity will be adjusted to be an
+            exact multiple of the turbine rating in order to yield an
+            integer number of turbines. For best results, set this
+            value to be an integer multiple of the turbine rating.
+
+        Returns
+        -------
+        capital_cost : float
+            Capital cost (per kW) for the (adjusted) plant capacity.
+        """
+
+        fixed_charge_rate = self.fixed_charge_rate
+        n_turbines = int(round(capacity_mw * 1e3 / self.turbine_capacity))
+        system_capacity = n_turbines * self.turbine_capacity
+        mult = self.wind_plant.sam_sys_inputs.get(
+            'capital_cost_multiplier', 1) / system_capacity
+        return eval(self.capital_cost_function, globals(), locals()) * mult
+
     @property
     @none_until_optimized
     def turbine_x(self):

--- a/reV/bespoke/place_turbines.py
+++ b/reV/bespoke/place_turbines.py
@@ -329,8 +329,8 @@ class PlaceTurbines:
         self.initialize_packing()
         self.optimize(**kwargs)
 
-    def capital_cost_per_kw_at(self, capacity_mw):
-        """Capital cost function (per kW) evaluated for a given capacity.
+    def capital_cost_per_kw(self, capacity_mw):
+        """Capital cost function ($ per kW) evaluated for a given capacity.
 
         The capacity will be adjusted to be an exact multiple of the
         turbine rating in order to yield an integer number of
@@ -348,7 +348,7 @@ class PlaceTurbines:
         Returns
         -------
         capital_cost : float
-            Capital cost (per kW) for the (adjusted) plant capacity.
+            Capital cost ($ per kW) for the (adjusted) plant capacity.
         """
 
         fixed_charge_rate = self.fixed_charge_rate

--- a/reV/supply_curve/supply_curve.py
+++ b/reV/supply_curve/supply_curve.py
@@ -734,19 +734,16 @@ class SupplyCurve:
             cost /= self._trans_table['capacity']  # $/MW
             self._trans_table['trans_cap_cost_per_mw'] = cost
 
-        if 'reinforcement_cost' in self._trans_table:
-            logger.info("'reinforcement_cost' column found in transmission "
-                        "table. Adding reinforcement costs to total LCOE.")
+        if 'reinforcement_cost_per_mw' in self._trans_table:
+            logger.info("'reinforcement_cost_per_mw' column found in "
+                        "transmission table. Adding reinforcement costs "
+                        "to total LCOE.")
             cf_mean_arr = self._trans_table['mean_cf'].values
             lcot = (cost * fcr) / (cf_mean_arr * 8760)
             lcoe = lcot + self._trans_table['mean_lcoe']
             self._trans_table['lcot_no_reinforcement'] = lcot
             self._trans_table['lcoe_no_reinforcement'] = lcoe
-
-            r_cost_mw = (self._trans_table['reinforcement_cost']
-                         / self._trans_table['capacity'])
-            self._trans_table['reinforcement_cost_per_mw'] = r_cost_mw
-            cost += r_cost_mw  # $/MW
+            cost += self._trans_table['reinforcement_cost_per_mw']  # $/MW
 
         cf_mean_arr = self._trans_table['mean_cf'].values
         lcot = (cost * fcr) / (cf_mean_arr * 8760)
@@ -1001,7 +998,7 @@ class SupplyCurve:
 
     def _determine_sort_on(self, sort_on):
         """Determine the `sort_on` column from user input and trans table"""
-        if 'reinforcement_cost' in self._trans_table:
+        if 'reinforcement_cost_per_mw' in self._trans_table:
             sort_on = sort_on or "lcoe_no_reinforcement"
         return sort_on or 'total_lcoe'
 

--- a/tests/test_supply_curve_compute.py
+++ b/tests/test_supply_curve_compute.py
@@ -344,7 +344,7 @@ def test_least_cost_full_with_reinforcement():
                                     f'costs_RI_{cap}MW.csv')
             in_table = pd.read_csv(in_table)
             out_fp = os.path.join(td, f'costs_RI_{cap}MW.csv')
-            in_table["reinforcement_cost"] = 0
+            in_table["reinforcement_cost_per_mw"] = 0
             in_table["reinforcement_dist_km"] = 0
             in_table.to_csv(out_fp, index=False)
             trans_tables.append(out_fp)
@@ -367,7 +367,7 @@ def test_least_cost_full_with_reinforcement():
                                     f'costs_RI_{cap}MW.csv')
             in_table = pd.read_csv(in_table)
             out_fp = os.path.join(td, f'costs_RI_{cap}MW.csv')
-            in_table["reinforcement_cost"] = 1e6
+            in_table["reinforcement_cost_per_mw"] = 1e6
             in_table["reinforcement_dist_km"] = 10
             in_table.to_csv(out_fp, index=False)
             trans_tables.append(out_fp)
@@ -397,7 +397,7 @@ def test_least_cost_simple_with_reinforcement():
                                     f'costs_RI_{cap}MW.csv')
             in_table = pd.read_csv(in_table)
             out_fp = os.path.join(td, f'costs_RI_{cap}MW.csv')
-            in_table["reinforcement_cost"] = 0
+            in_table["reinforcement_cost_per_mw"] = 0
             in_table["reinforcement_dist_km"] = 0
             in_table.to_csv(out_fp, index=False)
             trans_tables.append(out_fp)
@@ -413,7 +413,7 @@ def test_least_cost_simple_with_reinforcement():
                                     f'costs_RI_{cap}MW.csv')
             in_table = pd.read_csv(in_table)
             out_fp = os.path.join(td, f'costs_RI_{cap}MW.csv')
-            in_table["reinforcement_cost"] = 1e6
+            in_table["reinforcement_cost_per_mw"] = 1e6
             in_table["reinforcement_dist_km"] = 10
             in_table.to_csv(out_fp, index=False)
             trans_tables.append(out_fp)
@@ -439,7 +439,7 @@ def test_least_cost_full_pass_through():
                                     f'costs_RI_{cap}MW.csv')
             in_table = pd.read_csv(in_table)
             out_fp = os.path.join(td, f'costs_RI_{cap}MW.csv')
-            in_table["reinforcement_cost"] = 0
+            in_table["reinforcement_cost_per_mw"] = 0
             for col in check_cols:
                 in_table[col] = 0
             in_table.to_csv(out_fp, index=False)
@@ -471,7 +471,7 @@ def test_least_cost_simple_pass_through():
                                     f'costs_RI_{cap}MW.csv')
             in_table = pd.read_csv(in_table)
             out_fp = os.path.join(td, f'costs_RI_{cap}MW.csv')
-            in_table["reinforcement_cost"] = 0
+            in_table["reinforcement_cost_per_mw"] = 0
             for col in check_cols:
                 in_table[col] = 0
             in_table.to_csv(out_fp, index=False)


### PR DESCRIPTION
Added `eos_mult` and `reg_mult` columns to bespoke meta. The are computed directly from bespoke results and are required for ReEDS runs. Also deprecated `reinforcement_cost` in favor of `reinforcement_cost_per_mw` since [the former will no longer be part of new reinforcement tables](https://github.com/NREL/reVX/pull/174)