### PR TITLE
Updated Geothermal Cost Inputs

### DIFF
--- a/reV/SAM/generation.py
+++ b/reV/SAM/generation.py
@@ -1162,7 +1162,18 @@ class TroughPhysicalHeat(AbstractSamGenerationFromWeatherFile):
 
 
 class Geothermal(AbstractSamGenerationFromWeatherFile):
-    """Class for geothermal generation from SAM.
+    """reV-SAM geothermal generation.
+
+    Unlike wind or solar, reV geothermal dynamically sets the size of a
+    geothermal plant. In particular, the nameplate capacity is set to
+    match the resource potential (obtained form the input data) for each
+    site. As a result, reV allows users to input ``capital_cost_per_kw``
+    and ``fixed_operating_cost_per_kw`` instead of the flat
+    ``capital_cost`` and ``fixed_operating_cost`` values, respectively,
+    in the SAM technology config. If these inputs are detected, reV
+    calculates the total ``capital_cost`` and ``fixed_operating_cost``
+    based on the plant size and automatically adds them to the SAM
+    config on a per-site basis.
 
     As of 12/20/2022, the resource potential input is only used to
     calculate the number of well replacements during the lifetime of a

--- a/reV/generation/generation.py
+++ b/reV/generation/generation.py
@@ -104,6 +104,7 @@ class Gen(BaseGen):
                'windpower': WindPower,
                'mhkwave': MhkWave
                }
+    """reV technology options."""
 
     # Mapping of reV generation outputs to scale factors and units.
     # Type is scalar or array and corresponds to the SAM single-site output
@@ -523,6 +524,7 @@ class Gen(BaseGen):
             SAM technology to analyze (pvwattsv7, windpower, tcsmoltensalt,
             solarwaterheat, troughphysicalheat, lineardirectsteam)
             The string should be lower-cased with spaces and _ removed.
+            See :attr:`OPTIONS` for all available options.
         points : int | slice | list | str | PointsControl
             Slice specifying project points, or string pointing to a project
             points csv, or a fully instantiated PointsControl object. Can

--- a/tests/test_gen_geothermal.py
+++ b/tests/test_gen_geothermal.py
@@ -127,6 +127,61 @@ def test_gen_geothermal_temp_too_low():
             assert np.allclose(truth, test, rtol=RTOL, atol=ATOL), msg
 
 
+def test_per_kw_cost_inputs():
+    """Test per_kw cost inputs for geothermal module"""
+    points = slice(0, 1)
+    sam_files = TESTDATADIR + '/SAM/geothermal_default.json'
+
+    meta = pd.DataFrame({"latitude": [41.29], "longitude": [-71.86],
+                         "timezone": [-5]})
+    meta.index.name = "gid"
+
+    with TemporaryDirectory() as td:
+        geo_sam_file = os.path.join(td, "geothermal_sam.json")
+        geo_res_file = os.path.join(td, "test_geo.h5")
+        with open(sam_files, "r") as fh:
+            geo_config = json.load(fh)
+
+        geo_config["resource_depth"] = 2000
+        geo_config.pop("capital_cost", None)
+        geo_config.pop("fixed_operating_cost", None)
+        geo_config["capital_cost_per_kw"] = 3_000
+        geo_config["fixed_operating_cost_per_kw"] = 200
+        with open(geo_sam_file, "w") as fh:
+            json.dump(geo_config, fh)
+
+        with Outputs(geo_res_file, 'w') as f:
+            f.meta = meta
+            f.time_index = pd.date_range(start='1/1/2018', end='1/1/2019',
+                                         freq='H')[:-1]
+
+        Outputs.add_dataset(
+            geo_res_file, 'temperature_2000m', np.array([150]),
+            np.float32, attrs={"units": "C"},
+        )
+        Outputs.add_dataset(
+            geo_res_file, 'potential_MW_2000m', np.array([100]),
+            np.float32, attrs={"units": "MW"},
+        )
+
+        output_request = ('capital_cost', 'fixed_operating_cost', 'lcoe_fcr')
+        gen = Gen.reV_run('geothermal', points, geo_sam_file, geo_res_file,
+                          max_workers=1, output_request=output_request,
+                          sites_per_worker=1, out_fpath=None,
+                          scale_outputs=True)
+
+        truth_vals = {"capital_cost": 358_493_472,
+                      "fixed_operating_cost": 23899566,
+                      "lcoe_fcr": 67.82}
+        for dset in output_request:
+            truth = truth_vals[dset]
+            test = gen.out[dset]
+            msg = ('{} outputs do not match baseline value! Values differ '
+                   'at most by: {}'
+                   .format(dset, np.max(np.abs(truth - test))))
+            assert np.allclose(truth, test, rtol=RTOL, atol=ATOL), msg
+
+
 def execute_pytest(capture='all', flags='-rapP'):
     """Execute module as pytest with detailed summary report.
 


### PR DESCRIPTION
Since reV dynamically sets the size of a geothermal plant, it should update the associated costs accordingly. This patch allows users to input `capital_cost_per_kw` and `fixed_operating_cost_per_kw` instead of the flat `capital_cost` and `fixed_operating_cost` values, respectively. If these inputs are detected, reV calculates the total `capital_cost` and `fixed_operating_cost` based on the plant size and automatically adds them to the SAM config on a per-site basis. 