### PR TITLE
Custom Drill Costs for Geothermal

### DIFF
--- a/reV/SAM/defaults.py
+++ b/reV/SAM/defaults.py
@@ -48,8 +48,11 @@ class AbstractDefaultFromConfigFile:
             config = json.load(f)
 
         for k, v in config.items():
-            if 'adjust:' not in k and 'file' not in k:
-                obj.value(k, v)
+            if 'adjust:' in k or'file' in k :
+                continue
+            if 'geotherm.cost' in k:
+                k = k.replace(".", "_")
+            obj.value(k, v)
 
         obj.AdjustmentFactors.constant = 0.0
         return obj

--- a/reV/SAM/defaults/geothermal.json
+++ b/reV/SAM/defaults/geothermal.json
@@ -20,6 +20,7 @@
 	"temp_decline_rate" : 0.5,
 	"temp_decline_max" : 30,
 	"dt_prod_well" : 0,
+    "prod_well_choice" : 0,
 	"wet_bulb_temp" : 15,
 	"ambient_pressure" : 14.699999999999999,
 	"well_flow_rate" : 110,
@@ -28,6 +29,7 @@
 	"excess_pressure_pump" : 50,
 	"well_diameter" : 12.25,
 	"casing_size" : 9.625,
+    "inj_casing_size" : 11.5,
 	"inj_well_diam" : 12.25,
 	"design_temp" : 200,
 	"specify_pump_work" : 0,
@@ -42,6 +44,8 @@
 	"inj_prod_well_distance" : 1500,
 	"subsurface_water_loss" : 2,
 	"fracture_aperature" : 0.00040000000000000002,
+    "fracture_length" : 1000,
+    "fracture_spacing" : 50,
 	"fracture_width" : 175,
 	"num_fractures" : 6,
 	"fracture_angle" : 15,
@@ -71,5 +75,8 @@
 	"hc_ctl7" : 0,
 	"hc_ctl8" : 0,
 	"hc_ctl9" : 0,
-	"hybrid_dispatch_schedule" : "111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
+	"hybrid_dispatch_schedule" : "111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+    "geotherm.cost.inj_cost_curve_welltype" : 0,
+    "geotherm.cost.prod_cost_curve_welltype" : 0,
+    "geotherm.cost.inj_prod_well_ratio" : 0.5
 }

--- a/reV/SAM/generation.py
+++ b/reV/SAM/generation.py
@@ -1183,16 +1183,23 @@ class Geothermal(AbstractSamGenerationFromWeatherFile):
     Unlike wind or solar, reV geothermal dynamically sets the size of a
     geothermal plant. In particular, the nameplate capacity is set to
     match the resource potential (obtained form the input data) for each
-    site. As a result, reV allows users to input ``capital_cost_per_kw``
+    site. To override this behavior, users can specify their own
+    nameplate capacity (either a single value for all sites in the SAM
+    geothermal config or a site-dependent value in the project points
+    CSV). In this case, the resource potential from the input data will
+    be ignored completely.
+
+    reV also allows users to input ``capital_cost_per_kw``
     and ``fixed_operating_cost_per_kw`` instead of the flat
     ``capital_cost`` and ``fixed_operating_cost`` values, respectively,
-    in the SAM technology config. If these inputs are detected, reV
-    calculates the total ``capital_cost`` and ``fixed_operating_cost``
-    based on the plant size and automatically adds them to the SAM
-    config on a per-site basis. Users can also provide a
-    ``drill_cost_per_well`` value, which will be used to calculate
-    total drilling costs base don the number of wells at each plant.
-    The drilling costs will be added to the capital cost input.
+    in the SAM technology config, since the capacity of geothermal
+    plants may be set dynamically by reV. If these inputs are detected,
+    reV calculates the total ``capital_cost`` and
+    ``fixed_operating_cost`` based on the plant size and automatically
+    adds them to the SAM config on a per-site basis. Users can also
+    provide a ``drill_cost_per_well`` value, which will be used to
+    calculate total drilling costs base don the number of wells at each
+    plant. The drilling costs will be added to the capital cost input.
 
     As of 12/20/2022, the resource potential input is only used to
     calculate the number of well replacements during the lifetime of a
@@ -1300,6 +1307,13 @@ class Geothermal(AbstractSamGenerationFromWeatherFile):
     def _set_nameplate_to_match_resource_potential(self, resource):
         """Set the nameplate capacity to match the resource potential. """
 
+        if "nameplate" in self.sam_sys_inputs:
+            msg = ('Found "nameplate" input in config! Resource potential '
+                   'from input data will be ignored. Nameplate capacity is {}'
+                   .format(self.sam_sys_inputs["nameplate"]))
+            logger.info(msg)
+            return
+
         val = set(resource["potential_MW"].unique())
         if len(val) > 1:
             msg = ('Found multiple values for "potential_MW" for site {}: {}'
@@ -1308,12 +1322,6 @@ class Geothermal(AbstractSamGenerationFromWeatherFile):
             raise InputError(msg)
 
         val = val.pop() * 1000
-        if "nameplate" in self.sam_sys_inputs:
-            msg = ('Setting "nameplate" is not allowed! Updating '
-                   'user input of {} to match the resource potential: {}'
-                   .format(self.sam_sys_inputs["nameplate"], val))
-            logger.warning(msg)
-            warn(msg)
 
         logger.debug("Setting the nameplate to {}".format(val))
         self.sam_sys_inputs["nameplate"] = val

--- a/reV/generation/output_attributes/generation.json
+++ b/reV/generation/output_attributes/generation.json
@@ -159,6 +159,13 @@
     "type": "scalar",
     "units": "kWh/m2/day"
   },
+  "nameplate": {
+    "chunks": null,
+    "dtype": "float32",
+    "scale_factor": 1,
+    "type": "scalar",
+    "units": "kW"
+  },
   "poa": {
     "chunks": [
       null,

--- a/tests/data/SAM/geothermal_default.json
+++ b/tests/data/SAM/geothermal_default.json
@@ -19,7 +19,6 @@
     "subsurface_water_loss" : 2,
 
     "analysis_type" : 0,
-    "nameplate" : 30000,
     "num_wells" : 3,
     "num_wells_getem" : 4.2419632544315728,
     "conversion_type" : 0,

--- a/tests/test_gen_geothermal.py
+++ b/tests/test_gen_geothermal.py
@@ -333,9 +333,9 @@ def test_gen_egs_too_high_egs_plant_design_temp():
         output_request = ('design_temp',)
         with pytest.warns(UserWarning):
             gen = Gen.reV_run('geothermal', points, geo_sam_file, geo_res_file,
-                            max_workers=1, output_request=output_request,
-                            sites_per_worker=1, out_fpath=None,
-                            scale_outputs=True)
+                              max_workers=1, output_request=output_request,
+                              sites_per_worker=1, out_fpath=None,
+                              scale_outputs=True)
 
         truth_vals = {"design_temp": 150}
         for dset in output_request:

--- a/tests/test_gen_geothermal.py
+++ b/tests/test_gen_geothermal.py
@@ -238,6 +238,63 @@ def test_drill_cost_inputs():
             assert np.allclose(truth, test, rtol=1e-6, atol=ATOL), msg
 
 
+def test_gen_with_nameplate_input():
+    """Test generation for geothermal module"""
+    points = slice(0, 1)
+    sam_files = TESTDATADIR + '/SAM/geothermal_default.json'
+
+    meta = pd.DataFrame({"latitude": [41.29], "longitude": [-71.86],
+                         "timezone": [-5]})
+    meta.index.name = "gid"
+
+    with TemporaryDirectory() as td:
+        geo_sam_file = os.path.join(td, "geothermal_sam.json")
+        geo_res_file = os.path.join(td, "test_geo.h5")
+        with open(sam_files, "r") as fh:
+            geo_config = json.load(fh)
+
+        geo_config["resource_depth"] = 2000
+        geo_config["nameplate"] = 40000
+        with open(geo_sam_file, "w") as fh:
+            json.dump(geo_config, fh)
+
+        with Outputs(geo_res_file, 'w') as f:
+            f.meta = meta
+            f.time_index = pd.date_range(start='1/1/2018', end='1/1/2019',
+                                         freq='H')[:-1]
+
+        Outputs.add_dataset(
+            geo_res_file, 'temperature_2000m', np.array([150]),
+            np.float32, attrs={"units": "C"},
+        )
+        Outputs.add_dataset(
+            geo_res_file, 'potential_MW_2000m', np.array([20]),
+            np.float32, attrs={"units": "MW"},
+        )
+
+        output_request = ('annual_energy', 'cf_mean', 'cf_profile',
+                          'gen_profile', 'lcoe_fcr', 'nameplate')
+        gen = Gen.reV_run('geothermal', points, geo_sam_file, geo_res_file,
+                          max_workers=1, output_request=output_request,
+                          sites_per_worker=1, out_fpath=None,
+                          scale_outputs=True)
+
+        truth_vals = {"annual_energy": 3.47992e+08, "cf_mean": 0.993,
+                      "cf_profile": 0.993, "gen_profile": 39725.117,
+                      "lcoe_fcr": 62.613, "nameplate": 40_000,
+                      "resource_temp": 150}
+        for dset in output_request:
+            truth = truth_vals[dset]
+            test = gen.out[dset]
+            if len(test.shape) == 2:
+                test = np.mean(test, axis=0)
+
+            msg = ('{} outputs do not match baseline value! Values differ '
+                   'at most by: {}'
+                   .format(dset, np.max(np.abs(truth - test))))
+            assert np.allclose(truth, test, rtol=RTOL, atol=ATOL), msg
+
+
 def execute_pytest(capture='all', flags='-rapP'):
     """Execute module as pytest with detailed summary report.
 

--- a/tests/test_gen_geothermal.py
+++ b/tests/test_gen_geothermal.py
@@ -16,6 +16,7 @@ from reV.generation.generation import Gen
 from reV import TESTDATADIR
 from rex import Outputs
 
+DEFAULT_GEO_SAM_FILE = TESTDATADIR + '/SAM/geothermal_default.json'
 RTOL = 0.1
 ATOL = 0.01
 
@@ -24,7 +25,6 @@ ATOL = 0.01
 def test_gen_geothermal(depth):
     """Test generation for geothermal module"""
     points = slice(0, 1)
-    sam_files = TESTDATADIR + '/SAM/geothermal_default.json'
 
     meta = pd.DataFrame({"latitude": [41.29], "longitude": [-71.86],
                          "timezone": [-5]})
@@ -33,7 +33,7 @@ def test_gen_geothermal(depth):
     with TemporaryDirectory() as td:
         geo_sam_file = os.path.join(td, "geothermal_sam.json")
         geo_res_file = os.path.join(td, "test_geo.h5")
-        with open(sam_files, "r") as fh:
+        with open(DEFAULT_GEO_SAM_FILE, "r") as fh:
             geo_config = json.load(fh)
 
         geo_config["resource_depth"] = depth
@@ -80,7 +80,6 @@ def test_gen_geothermal(depth):
 def test_gen_geothermal_temp_too_low():
     """Test generation for geothermal module when temp too low"""
     points = slice(0, 1)
-    sam_files = TESTDATADIR + '/SAM/geothermal_default.json'
 
     meta = pd.DataFrame({"latitude": [41.29], "longitude": [-71.86],
                          "timezone": [-5]})
@@ -89,7 +88,7 @@ def test_gen_geothermal_temp_too_low():
     with TemporaryDirectory() as td:
         geo_sam_file = os.path.join(td, "geothermal_sam.json")
         geo_res_file = os.path.join(td, "test_geo.h5")
-        shutil.copy(sam_files, geo_sam_file)
+        shutil.copy(DEFAULT_GEO_SAM_FILE, geo_sam_file)
 
         with Outputs(geo_res_file, 'w') as f:
             f.meta = meta
@@ -130,7 +129,6 @@ def test_gen_geothermal_temp_too_low():
 def test_per_kw_cost_inputs():
     """Test per_kw cost inputs for geothermal module"""
     points = slice(0, 1)
-    sam_files = TESTDATADIR + '/SAM/geothermal_default.json'
 
     meta = pd.DataFrame({"latitude": [41.29], "longitude": [-71.86],
                          "timezone": [-5]})
@@ -139,7 +137,7 @@ def test_per_kw_cost_inputs():
     with TemporaryDirectory() as td:
         geo_sam_file = os.path.join(td, "geothermal_sam.json")
         geo_res_file = os.path.join(td, "test_geo.h5")
-        with open(sam_files, "r") as fh:
+        with open(DEFAULT_GEO_SAM_FILE, "r") as fh:
             geo_config = json.load(fh)
 
         geo_config["resource_depth"] = 2000
@@ -185,7 +183,6 @@ def test_per_kw_cost_inputs():
 def test_drill_cost_inputs():
     """Test per_kw cost inputs for geothermal module"""
     points = slice(0, 1)
-    sam_files = TESTDATADIR + '/SAM/geothermal_default.json'
 
     meta = pd.DataFrame({"latitude": [41.29], "longitude": [-71.86],
                          "timezone": [-5]})
@@ -194,7 +191,7 @@ def test_drill_cost_inputs():
     with TemporaryDirectory() as td:
         geo_sam_file = os.path.join(td, "geothermal_sam.json")
         geo_res_file = os.path.join(td, "test_geo.h5")
-        with open(sam_files, "r") as fh:
+        with open(DEFAULT_GEO_SAM_FILE, "r") as fh:
             geo_config = json.load(fh)
 
         geo_config["resource_depth"] = 2000
@@ -241,7 +238,6 @@ def test_drill_cost_inputs():
 def test_gen_with_nameplate_input():
     """Test generation for geothermal module with user nameplate input"""
     points = slice(0, 1)
-    sam_files = TESTDATADIR + '/SAM/geothermal_default.json'
 
     meta = pd.DataFrame({"latitude": [41.29], "longitude": [-71.86],
                          "timezone": [-5]})
@@ -250,7 +246,7 @@ def test_gen_with_nameplate_input():
     with TemporaryDirectory() as td:
         geo_sam_file = os.path.join(td, "geothermal_sam.json")
         geo_res_file = os.path.join(td, "test_geo.h5")
-        with open(sam_files, "r") as fh:
+        with open(DEFAULT_GEO_SAM_FILE, "r") as fh:
             geo_config = json.load(fh)
 
         geo_config["resource_depth"] = 2000
@@ -298,7 +294,6 @@ def test_gen_with_nameplate_input():
 def test_gen_egs_too_high_egs_plant_design_temp():
     """Test generation for EGS too high plant design temp"""
     points = slice(0, 1)
-    sam_files = TESTDATADIR + '/SAM/geothermal_default.json'
 
     meta = pd.DataFrame({"latitude": [41.29], "longitude": [-71.86],
                          "timezone": [-5]})
@@ -307,7 +302,7 @@ def test_gen_egs_too_high_egs_plant_design_temp():
     with TemporaryDirectory() as td:
         geo_sam_file = os.path.join(td, "geothermal_sam.json")
         geo_res_file = os.path.join(td, "test_geo.h5")
-        with open(sam_files, "r") as fh:
+        with open(DEFAULT_GEO_SAM_FILE, "r") as fh:
             geo_config = json.load(fh)
 
         geo_config["resource_depth"] = 2000

--- a/tests/test_gen_geothermal.py
+++ b/tests/test_gen_geothermal.py
@@ -170,16 +170,72 @@ def test_per_kw_cost_inputs():
                           sites_per_worker=1, out_fpath=None,
                           scale_outputs=True)
 
-        truth_vals = {"capital_cost": 358_493_472,
-                      "fixed_operating_cost": 23899566,
-                      "lcoe_fcr": 67.82}
+        truth_vals = {"capital_cost": 383_086_656,
+                      "fixed_operating_cost": 25539104,
+                      "lcoe_fcr": 72.5092}
         for dset in output_request:
             truth = truth_vals[dset]
             test = gen.out[dset]
             msg = ('{} outputs do not match baseline value! Values differ '
                    'at most by: {}'
                    .format(dset, np.max(np.abs(truth - test))))
-            assert np.allclose(truth, test, rtol=RTOL, atol=ATOL), msg
+            assert np.allclose(truth, test, rtol=1e-6, atol=ATOL), msg
+
+
+def test_drill_cost_inputs():
+    """Test per_kw cost inputs for geothermal module"""
+    points = slice(0, 1)
+    sam_files = TESTDATADIR + '/SAM/geothermal_default.json'
+
+    meta = pd.DataFrame({"latitude": [41.29], "longitude": [-71.86],
+                         "timezone": [-5]})
+    meta.index.name = "gid"
+
+    with TemporaryDirectory() as td:
+        geo_sam_file = os.path.join(td, "geothermal_sam.json")
+        geo_res_file = os.path.join(td, "test_geo.h5")
+        with open(sam_files, "r") as fh:
+            geo_config = json.load(fh)
+
+        geo_config["resource_depth"] = 2000
+        geo_config.pop("capital_cost", None)
+        geo_config.pop("fixed_operating_cost", None)
+        geo_config["capital_cost_per_kw"] = 3_000
+        geo_config["fixed_operating_cost_per_kw"] = 200
+        geo_config["drill_cost_per_well"] = 2_500_000
+        with open(geo_sam_file, "w") as fh:
+            json.dump(geo_config, fh)
+
+        with Outputs(geo_res_file, 'w') as f:
+            f.meta = meta
+            f.time_index = pd.date_range(start='1/1/2018', end='1/1/2019',
+                                         freq='H')[:-1]
+
+        Outputs.add_dataset(
+            geo_res_file, 'temperature_2000m', np.array([150]),
+            np.float32, attrs={"units": "C"},
+        )
+        Outputs.add_dataset(
+            geo_res_file, 'potential_MW_2000m', np.array([100]),
+            np.float32, attrs={"units": "MW"},
+        )
+
+        output_request = ('capital_cost', 'fixed_operating_cost', 'lcoe_fcr')
+        gen = Gen.reV_run('geothermal', points, geo_sam_file, geo_res_file,
+                          max_workers=1, output_request=output_request,
+                          sites_per_worker=1, out_fpath=None,
+                          scale_outputs=True)
+
+        truth_vals = {"capital_cost": 466_134_733,
+                      "fixed_operating_cost": 25539104,
+                      "lcoe_fcr": 81.8643}
+        for dset in output_request:
+            truth = truth_vals[dset]
+            test = gen.out[dset]
+            msg = ('{} outputs do not match baseline value! Values differ '
+                   'at most by: {}'
+                   .format(dset, np.max(np.abs(truth - test))))
+            assert np.allclose(truth, test, rtol=1e-6, atol=ATOL), msg
 
 
 def execute_pytest(capture='all', flags='-rapP'):


### PR DESCRIPTION
This PR adds the ability for users to add `drill_cost_per_well` as an input to the SAM configs so that the capital cost can be adjusted accordingly. This gives much more realistic cost values for large depths (eg 4-10km).

This PR also allows users to input a nameplate value in the SAM config to override the data input.

Finally, this PR adds a fix for EGS plant temperature - this value will now be adjusted to match the temperature input from the resource data. SAM throws an error otherwise, which messes up a large portion of the EGS data points.

Labeling as Urgent b/c we would like to get one of the analysist running some supply curves with these changes this week.