### PR TITLE
Fix out path bug

### DIFF
--- a/.github/linters/.flake8
+++ b/.github/linters/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-ignore = E731,E402,F,W503
+ignore = E731,E402,F,W503,W605,D
 exclude = .git,__pycache__,docs/source/conf.py,old,build,dist,bin/tmp/*
 max-complexity = 10

--- a/reV/generation/base.py
+++ b/reV/generation/base.py
@@ -869,25 +869,26 @@ class BaseGen(ABC):
         if out_fpath is None:
             return
 
-        # ensure output file is an h5
-        if not out_fpath.endswith('.h5'):
-            out_fpath += '.h5'
+        project_dir, out_fn = os.path.split(out_fpath)
 
-        if module not in out_fpath:
+        # ensure output file is an h5
+        if not out_fn.endswith('.h5'):
+            out_fn += '.h5'
+
+        if module not in out_fn:
             extension_with_module = "_{}.h5".format(module)
-            out_fpath = out_fpath.replace(".h5", extension_with_module)
+            out_fn = out_fn.replace(".h5", extension_with_module)
 
         # ensure year is in out_fpath
-        if self.year is not None and str(self.year) not in out_fpath:
+        if self.year is not None and str(self.year) not in out_fn:
             module_with_year = "{}_{}".format(module, self.year)
-            out_fpath = out_fpath.replace(module, module_with_year)
+            out_fn = out_fn.replace(module, module_with_year)
 
         # create and use optional output dir
-        dirout = os.path.dirname(out_fpath)
-        if dirout and not os.path.exists(dirout):
-            os.makedirs(dirout)
+        if project_dir and not os.path.exists(project_dir):
+            os.makedirs(project_dir)
 
-        self._out_fpath = out_fpath
+        self._out_fpath = os.path.join(project_dir, out_fn)
         self._run_attrs['out_fpath'] = out_fpath
 
     def _init_h5(self, mode='w'):

--- a/reV/generation/base.py
+++ b/reV/generation/base.py
@@ -881,8 +881,8 @@ class BaseGen(ABC):
 
         # ensure year is in out_fpath
         if self.year is not None and str(self.year) not in out_fn:
-            module_with_year = "{}_{}".format(module, self.year)
-            out_fn = out_fn.replace(module, module_with_year)
+            extension_with_year = "_{}.h5".format(self.year)
+            out_fn = out_fn.replace(".h5", extension_with_year)
 
         # create and use optional output dir
         if project_dir and not os.path.exists(project_dir):

--- a/reV/generation/base.py
+++ b/reV/generation/base.py
@@ -886,7 +886,7 @@ class BaseGen(ABC):
 
         # create and use optional output dir
         if project_dir and not os.path.exists(project_dir):
-            os.makedirs(project_dir)
+            os.makedirs(project_dir, exist_ok=True)
 
         self._out_fpath = os.path.join(project_dir, out_fn)
         self._run_attrs['out_fpath'] = out_fpath

--- a/reV/qa_qc/qa_qc.py
+++ b/reV/qa_qc/qa_qc.py
@@ -33,7 +33,7 @@ class QaQc:
         log_versions(logger)
         logger.info('QA/QC results to be saved to: {}'.format(out_dir))
         if not os.path.exists(out_dir):
-            os.makedirs(out_dir)
+            os.makedirs(out_dir, exist_ok=True)
 
         self._out_dir = out_dir
 
@@ -71,7 +71,7 @@ class QaQc:
         out_dir = os.path.join(out_root,
                                os.path.basename(summary_csv).rstrip('.csv'))
         if not os.path.exists(out_dir):
-            os.makedirs(out_dir)
+            os.makedirs(out_dir, exist_ok=True)
 
         SummaryPlots.scatter_all(summary_csv, out_dir, plot_type=plot_type,
                                  cmap=cmap, **kwargs)

--- a/reV/qa_qc/summary.py
+++ b/reV/qa_qc/summary.py
@@ -245,7 +245,7 @@ class SummarizeH5:
             by default None
         """
         if not os.path.exists(out_dir):
-            os.makedirs(out_dir)
+            os.makedirs(out_dir, exist_ok=True)
 
         if dsets is None:
             with Resource(h5_file, group=group) as f:
@@ -389,7 +389,7 @@ class SummarizeSupplyCurve:
             by default None
         """
         if not os.path.exists(out_dir):
-            os.makedirs(out_dir)
+            os.makedirs(out_dir, exist_ok=True)
 
         summary = cls(sc_table)
         out_path = os.path.basename(sc_table).replace('.csv', '_summary.csv')

--- a/reV/rep_profiles/cli_rep_profiles.py
+++ b/reV/rep_profiles/cli_rep_profiles.py
@@ -80,6 +80,7 @@ def _preprocessor(config, out_dir, job_name, analysis_years=None):
 def _set_split_keys(config, out_dir, job_name, analysis_years):
     """Set the gen_fpath, fout, and cf_dset keys"""
 
+    job_name = job_name.replace("rep_profiles", "rep-profiles")
     cf_dset = config.get("cf_dset")
     gen_fpath = config.get("gen_fpath")
     if analysis_years[0] is not None and '{}' in cf_dset:

--- a/reV/supply_curve/sc_aggregation.py
+++ b/reV/supply_curve/sc_aggregation.py
@@ -1300,9 +1300,18 @@ class SupplyCurveAggregation(BaseAggregation):
                                      max_workers=max_workers,
                                      sites_per_worker=sites_per_worker)
 
-        if not out_fpath.endswith(".csv"):
-            out_fpath = '{}.csv'.format(out_fpath)
-
+        out_fpath = _format_sc_agg_out_fpath(out_fpath)
         summary.to_csv(out_fpath)
 
         return out_fpath
+
+
+def _format_sc_agg_out_fpath(out_fpath):
+    """Add CSV file ending and replace underscore, if necessary."""
+    if not out_fpath.endswith(".csv"):
+        out_fpath = '{}.csv'.format(out_fpath)
+
+    project_dir, out_fn = os.path.split(out_fpath)
+    out_fn = out_fn.replace("supply_curve_aggregation",
+                            "supply-curve-aggregation")
+    return os.path.join(project_dir, out_fn)

--- a/reV/supply_curve/supply_curve.py
+++ b/reV/supply_curve/supply_curve.py
@@ -1442,9 +1442,17 @@ class SupplyCurve:
             kwargs["line_limited"] = line_limited
             supply_curve = self.full_sort(**kwargs)
 
-        if not out_fpath.endswith(".csv"):
-            out_fpath = '{}.csv'.format(out_fpath)
-
+        out_fpath = _format_sc_out_fpath(out_fpath)
         supply_curve.to_csv(out_fpath, index=False)
 
         return out_fpath
+
+
+def _format_sc_out_fpath(out_fpath):
+    """Add CSV file ending and replace underscore, if necessary."""
+    if not out_fpath.endswith(".csv"):
+        out_fpath = '{}.csv'.format(out_fpath)
+
+    project_dir, out_fn = os.path.split(out_fpath)
+    out_fn = out_fn.replace("supply_curve", "supply-curve")
+    return os.path.join(project_dir, out_fn)

--- a/reV/version.py
+++ b/reV/version.py
@@ -2,4 +2,4 @@
 reV Version number
 """
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-NREL-gaps>=0.4.0
+NREL-gaps>=0.4.2
 NREL-NRWAL>=0.0.7
 NREL-PySAM~=4.1.0
 NREL-rex>=0.2.80

--- a/tests/test_gen_config.py
+++ b/tests/test_gen_config.py
@@ -48,6 +48,9 @@ def test_gen_from_config(runner, tech, clear_loggers):  # noqa: C901
     """Gen PV CF profiles with write to disk and compare against rev1."""
     with tempfile.TemporaryDirectory() as td:
 
+        run_dir = os.path.join(td, 'generation')
+        os.mkdir(run_dir)
+
         if tech == 'pv':
             fconfig = 'local_pv.json'
             project_points = os.path.join(TESTDATADIR, 'config', '..',
@@ -72,9 +75,9 @@ def test_gen_from_config(runner, tech, clear_loggers):  # noqa: C901
         config['project_points'] = project_points
         config['resource_file'] = resource_file
         config['sam_files'] = sam_files
-        config['log_directory'] = td
+        config['log_directory'] = run_dir
 
-        config_path = os.path.join(td, 'config.json')
+        config_path = os.path.join(run_dir, 'config.json')
         with open(config_path, 'w') as f:
             json.dump(config, f)
 
@@ -83,13 +86,15 @@ def test_gen_from_config(runner, tech, clear_loggers):  # noqa: C901
                .format(traceback.print_exception(*result.exc_info)))
         assert result.exit_code == 0, msg
 
+        assert len(os.listdir(td)) == 1
+
         # get reV 2.0 generation profiles from disk
         rev2_profiles = None
-        flist = os.listdir(td)
+        flist = os.listdir(run_dir)
         print(flist)
         for fname in flist:
             if fname.endswith('.h5'):
-                path = os.path.join(td, fname)
+                path = os.path.join(run_dir, fname)
                 with Outputs(path, 'r') as cf:
 
                     msg = 'cf_profile not written to disk'

--- a/tests/test_supply_curve_sc_aggregation.py
+++ b/tests/test_supply_curve_sc_aggregation.py
@@ -442,8 +442,7 @@ def test_cli_basic_agg(runner, clear_loggers):
         fn_list = os.listdir(td)
         dirname = os.path.basename(td)
         out_csv_fn = ('{}_{}.csv'
-                      .format(dirname, ModuleName.SUPPLY_CURVE_AGGREGATION)
-                      .replace("-", "_"))
+                      .format(dirname, ModuleName.SUPPLY_CURVE_AGGREGATION))
         assert out_csv_fn in fn_list
 
 


### PR DESCRIPTION
Previous version of code would add a year value to the module name everywhere in the path.
For example, a generation run for year 2012 in the directory  `/my/path/to/generation/runs` would give an output file in `/my/path/to/generation_2012/run/generation_2012.h5`. New version of code only performs this substitution in the file name. 