### PR TITLE
Add support for NRWAL CSV output

### DIFF
--- a/tests/test_nrwal.py
+++ b/tests/test_nrwal.py
@@ -420,7 +420,6 @@ def test_nrwal_cli_csv(runner, clear_loggers):
                         np.float32, attrs={'scale_factor': 1},
                         chunks=None)
 
-
         output_request = ['fixed_charge_rate', 'depth', 'total_losses',
                           'array', 'export', 'gcf_adjustment',
                           'lcoe_fcr', 'cf_mean', 'cf_profile']


### PR DESCRIPTION
I added a version of this code back in Feb 2022 when we were doing hydrogen runs but never merged it because it made the CLI somewhat messy. This PR finally merges a version of that code. This option is mainly intended to support huge (50k-100k) batched parametric NRWAL runs. Travis indicated the need for this kind of feature in some of the upcoming green steel work, for example.