### PR TITLE
GAPs 0.6.0

### DIFF
--- a/.github/workflows/pr_revx_tests.yml
+++ b/.github/workflows/pr_revx_tests.yml
@@ -33,11 +33,9 @@ jobs:
       working-directory: ./reVX
       shell: bash -l {0}
       run: |
-        conda install rtree pytest
-        pip install geopandas
-        pip install --upgrade --force-reinstall shapely~=1.8
+        conda install rtree pip pytest
         pip install -e .
-        pip install HOPP
+        pip install HOPP==0.0.5
     - name: Run reVX pytest
       working-directory: ./reVX
       shell: bash -l {0}

--- a/README.rst
+++ b/README.rst
@@ -168,7 +168,9 @@ reV command line tools
 - `reV hybrids <https://nrel.github.io/reV/_cli/reV%20hybrids.html>`_
 - `reV nrwal <https://nrel.github.io/reV/_cli/reV%20nrwal.html>`_
 - `reV qa-qc <https://nrel.github.io/reV/_cli/reV%20qa-qc.html>`_
+- `reV script <https://nrel.github.io/reV/_cli/reV%20script.html>`_
 - `reV status <https://nrel.github.io/reV/_cli/reV%20status.html>`_
+- `reV reset-status <https://nrel.github.io/reV/_cli/reV%20reset-status.html>`_
 
 
 Launching a run

--- a/docs/source/_cli/cli.rst
+++ b/docs/source/_cli/cli.rst
@@ -21,4 +21,6 @@ Command Line Interfaces (CLIs)
    reV hybrids
    reV nrwal
    reV qa-qc
+   reV script
    reV status
+   reV reset-status

--- a/docs/source/_cli/reV reset-status.rst
+++ b/docs/source/_cli/reV reset-status.rst
@@ -1,0 +1,3 @@
+.. click:: reV.cli:reset_status
+   :prog: reV reset-status
+   :nested: none

--- a/docs/source/_cli/reV script.rst
+++ b/docs/source/_cli/reV script.rst
@@ -1,0 +1,3 @@
+.. click:: reV.cli:script
+   :prog: reV script
+   :nested: none

--- a/examples/running_with_hsds/README.rst
+++ b/examples/running_with_hsds/README.rst
@@ -37,8 +37,8 @@ To get your own API key, visit https://developer.nrel.gov/signup/
 
 Please note that our HSDS service is for demonstration purposes only. The API in the example above is hosted on an NREL server and will have limits on the amount of data you can access via HSDS. It is common to get an error: ``OSError: Error retrieving data: None errors`` if you attempt to access too much data or if the server is busy. Here are two references for scaling reV using HSDS and AWS:
 
-#. `Setup your own HSDS server on your personal computer<https://nrel.github.io/rex/misc/examples.hsds.html#>`_
-#. `Run reV on the AWS Parallel Cluster Infrastructure<https://nrel.github.io/reV/misc/examples.aws_pcluster.html>`_
+#. `Setup your own HSDS server on your personal computer <https://nrel.github.io/rex/misc/examples.hsds.html#>`_
+#. `Run reV on the AWS Parallel Cluster Infrastructure <https://nrel.github.io/reV/misc/examples.aws_pcluster.html>`_
 
 Using HSDS with reV
 -------------------

--- a/reV/cli.py
+++ b/reV/cli.py
@@ -33,7 +33,9 @@ main.add_command(project_points)
 # export GAPs commands to namespace for documentation
 batch = main.commands["batch"]
 pipeline = main.commands["pipeline"]
+script = main.commands["script"]
 status = main.commands["status"]
+reset_status = main.commands["reset-status"]
 template_configs = main.commands["template-configs"]
 
 

--- a/reV/econ/econ.py
+++ b/reV/econ/econ.py
@@ -126,11 +126,18 @@ class Econ(BaseGen):
             inputs.
         cf_file : str
             Path to reV output generation file containing a capacity
-            factor output. If executing ``reV`` from the command line,
-            this path can contain brackets ``{}`` that will be filled in
-            by the `analysis_years` input. Alternatively, this input can
-            be set to ``"PIPELINE"`` to parse the output of the previous
-            step (``reV`` generation) and use it as input to this call.
+            factor output.
+
+            .. Note:: If executing ``reV`` from the command line, this
+              path can contain brackets ``{}`` that will be filled in
+              by the `analysis_years` input. Alternatively, this input
+              can be set to ``"PIPELINE"`` to parse the output of the
+              previous step (``reV`` generation) and use it as input to
+              this call. However, note that duplicate executions of
+              ``reV`` generation within the pipeline may invalidate this
+              parsing, meaning the `cf_file` input will have to be
+              specified manually.
+
         site_data : str | pd.DataFrame, optional
             Site-specific input data for SAM calculation. If this input
             is a string, it should be a path that points to a CSV file.

--- a/reV/generation/generation.py
+++ b/reV/generation/generation.py
@@ -220,9 +220,10 @@ class Gen(BaseGen):
             the dimensions of (``time_index``, ``meta``). The time index
             must start at 00:00 of January 1st of the year under
             consideration, and its shape must be a multiple of 8760.
-            If executing ``reV`` from the command line, this path can
-            contain brackets ``{}`` that will be filled in by the
-            `analysis_years` input.
+
+            .. Note:: If executing ``reV`` from the command line, this
+              path can contain brackets ``{}`` that will be filled in by
+              the `analysis_years` input.
 
             .. Important:: If you are using custom resource data (i.e.
               not NSRDB/WTK/Sup3rCC, etc.), ensure the following:

--- a/reV/nrwal/nrwal.py
+++ b/reV/nrwal/nrwal.py
@@ -50,10 +50,16 @@ class RevNrwal:
         gen_fpath : str
             Full filepath to HDF5 file with ``reV`` generation or
             rep_profiles output. Anything in the `output_request` input
-            is added to and/or manipulated within this file. If running
-            ``reV`` from the command line, this input can also be
-            ``"PIPELINE"`` to parse the output of the previous step and
-            use it as input to this call.
+            is added to and/or manipulated within this file.
+
+            .. Note:: If executing ``reV`` from the command line, this
+              input can also be ``"PIPELINE"`` to parse the output of
+              one of the previous step and use it as input to this call.
+              However, note that duplicate executions of ``reV``
+              commands prior to this one within the pipeline may
+              invalidate this parsing, meaning the `gen_fpath` input
+              will have to be specified manually.
+
         site_data : str | pd.DataFrame
             Site-specific input data for NRWAL calculation.If this input
             is a string, it should be a path that points to a CSV file.
@@ -798,7 +804,6 @@ class RevNrwal:
             can be useful if the same HDF5 file is used for multiple
             sets of NRWAL runs. Note that all requested output datasets
             must be 1-dimensional in order to fir within the CSV output.
-            By default, ``False``.
 
             .. Important:: This option is not compatible with
               ``save_raw=True``. If you set ``csv_output=True``, then
@@ -810,6 +815,7 @@ class RevNrwal:
               an "input_dataset_name_raw" dataset to your generation
               HDF5 file before running NRWAL.
 
+            By default, ``False``.
         out_fpath : str, optional
             This option has no effect if ``csv_output=False``.
             Otherwise, this should be the full path to output NRWAL CSV

--- a/reV/qa_qc/qa_qc.py
+++ b/reV/qa_qc/qa_qc.py
@@ -284,8 +284,7 @@ class QaQcModule:
         if fpath == 'PIPELINE':
             target_modules = [self._name]
             for target_module in target_modules:
-                fpath = Status.parse_command_status(self._out_root,
-                                                    target_module)
+                fpath = Status.parse_step_status(self._out_root, target_module)
                 if fpath:
                     break
             else:
@@ -351,9 +350,9 @@ class QaQcModule:
 
         if excl_fpath == 'PIPELINE':
             target_module = ModuleName.SUPPLY_CURVE_AGGREGATION
-            excl_fpath = Status.parse_command_status(self._out_root,
-                                                     target_module,
-                                                     key='excl_fpath')
+            excl_fpath = Status.parse_step_status(self._out_root,
+                                                  target_module,
+                                                  key='excl_fpath')
             if not excl_fpath:
                 excl_fpath = None
                 msg = ('Could not parse excl_fpath from previous '
@@ -375,9 +374,8 @@ class QaQcModule:
 
         if excl_dict == 'PIPELINE':
             target_module = ModuleName.SUPPLY_CURVE_AGGREGATION
-            excl_dict = Status.parse_command_status(self._out_root,
-                                                    target_module,
-                                                    key='excl_dict')
+            excl_dict = Status.parse_step_status(self._out_root, target_module,
+                                                 key='excl_dict')
             if not excl_dict:
                 excl_dict = None
                 msg = ('Could not parse excl_dict from previous '
@@ -400,9 +398,9 @@ class QaQcModule:
         if area_filter_kernel == 'PIPELINE':
             target_module = ModuleName.SUPPLY_CURVE_AGGREGATION
             key = 'area_filter_kernel'
-            area_filter_kernel = Status.parse_command_status(self._out_root,
-                                                             target_module,
-                                                             key=key)
+            area_filter_kernel = Status.parse_step_status(self._out_root,
+                                                          target_module,
+                                                          key=key)
             if not area_filter_kernel:
                 area_filter_kernel = self._default_area_filter_kernel
                 msg = ('Could not parse area_filter_kernel from previous '
@@ -425,9 +423,8 @@ class QaQcModule:
 
         if min_area == 'PIPELINE':
             target_module = ModuleName.SUPPLY_CURVE_AGGREGATION
-            min_area = Status.parse_command_status(self._out_root,
-                                                   target_module,
-                                                   key='min_area')
+            min_area = Status.parse_step_status(self._out_root, target_module,
+                                                key='min_area')
             if not min_area:
                 min_area = None
                 msg = ('Could not parse min_area from previous '

--- a/reV/rep_profiles/rep_profiles.py
+++ b/reV/rep_profiles/rep_profiles.py
@@ -901,7 +901,14 @@ class RepProfiles(RepProfilesBase):
             Filepath to ``reV`` generation output HDF5 file to extract
             `cf_dset` dataset from. If executing ``reV`` from the
             command line, this path can contain brackets ``{}`` that
-            will be filled in by the `analysis_years` input.
+            will be filled in by the `analysis_years` input. If running
+            ``reV`` from the command line, this input can be set to
+            ``"PIPELINE"``, which will parse this input from the
+            following pipeline steps: `multi-year`, `collect`,
+            `generation`, and `supply-curve-aggregation`. However, note
+            that duplicate executions of any of these commands within
+            the pipeline may invalidate this parsing, meaning the
+            `gen_fpath` input will have to be specified manually.
         rev_summary : str | pd.DataFrame
             Aggregated ``reV`` supply curve summary file. Must include
             the following columns:
@@ -916,6 +923,13 @@ class RepProfiles(RepProfilesBase):
                   representation of python list containing the resource
                   GID weights for each supply curve point.
 
+            If running ``reV`` from the command line, this input can be
+            set to ``"PIPELINE"``, which will parse this input from the
+            following pipeline steps: `supply-curve-aggregation` and
+            `supply-curve`. However, note that duplicate executions of
+            any of these commands within the pipeline may invalidate
+            this parsing, meaning the `rev_summary` input will have to
+            be specified manually.
         reg_cols : str | list
             Label(s) for a categorical region column(s) to extract
             profiles for. For example, ``"state"`` will extract a rep

--- a/reV/rep_profiles/rep_profiles.py
+++ b/reV/rep_profiles/rep_profiles.py
@@ -899,16 +899,19 @@ class RepProfiles(RepProfilesBase):
         ----------
         gen_fpath : str
             Filepath to ``reV`` generation output HDF5 file to extract
-            `cf_dset` dataset from. If executing ``reV`` from the
-            command line, this path can contain brackets ``{}`` that
-            will be filled in by the `analysis_years` input. If running
-            ``reV`` from the command line, this input can be set to
-            ``"PIPELINE"``, which will parse this input from the
-            following pipeline steps: `multi-year`, `collect`,
-            `generation`, and `supply-curve-aggregation`. However, note
-            that duplicate executions of any of these commands within
-            the pipeline may invalidate this parsing, meaning the
-            `gen_fpath` input will have to be specified manually.
+            `cf_dset` dataset from.
+
+            .. Note:: If executing ``reV`` from the command line, this
+              path can contain brackets ``{}`` that will be filled in by
+              the `analysis_years` input. Alternatively, this input can
+              be set to ``"PIPELINE"``, which will parse this input from
+              one of these preceding pipeline steps: ``multi-year``,
+              ``collect``, ``generation``, or
+              ``supply-curve-aggregation``. However, note that duplicate
+              executions of any of these commands within the pipeline
+              may invalidate this parsing, meaning the `gen_fpath` input
+              will have to be specified manually.
+
         rev_summary : str | pd.DataFrame
             Aggregated ``reV`` supply curve summary file. Must include
             the following columns:
@@ -923,13 +926,15 @@ class RepProfiles(RepProfilesBase):
                   representation of python list containing the resource
                   GID weights for each supply curve point.
 
-            If running ``reV`` from the command line, this input can be
-            set to ``"PIPELINE"``, which will parse this input from the
-            following pipeline steps: `supply-curve-aggregation` and
-            `supply-curve`. However, note that duplicate executions of
-            any of these commands within the pipeline may invalidate
-            this parsing, meaning the `rev_summary` input will have to
-            be specified manually.
+            .. Note:: If executing ``reV`` from the command line, this
+              input can be set to ``"PIPELINE"``, which will parse this
+              input from one of these preceding pipeline steps:
+              ``supply-curve-aggregation`` or ``supply-curve``.
+              However, note that duplicate executions of any of these
+              commands within the pipeline may invalidate this parsing,
+              meaning the `rev_summary` input will have to be specified
+              manually.
+
         reg_cols : str | list
             Label(s) for a categorical region column(s) to extract
             profiles for. For example, ``"state"`` will extract a rep
@@ -939,8 +944,13 @@ class RepProfiles(RepProfilesBase):
             ``"sc_gid"``.
         cf_dset : str, optional
             Dataset name to pull generation profiles from. This dataset
-            must be present in the `gen_fpath` HDF5 file.
-            By default, ``"cf_profile"``
+            must be present in the `gen_fpath` HDF5 file. By default,
+            ``"cf_profile"``
+
+            .. Note:: If executing ``reV`` from the command line, this
+              name can contain brackets ``{}`` that will be filled in by
+              the `analysis_years` input (e.g. ``"cf_profile-{}"``).
+
         rep_method : {'mean', 'meanoid', 'median', 'medianoid'}, optional
             Method identifier for calculation of the representative
             profile. By default, ``'meanoid'``

--- a/reV/supply_curve/exclusions.py
+++ b/reV/supply_curve/exclusions.py
@@ -40,7 +40,6 @@ class LayerMask:
             Layer name.
         exclude_values : int | float | list, optional
             Single value or list of values to exclude.
-            By default, ``None``.
 
             .. Important:: The keyword arguments `exclude_values`,
               `exclude_range`, `include_values`, `include_range`,
@@ -48,6 +47,7 @@ class LayerMask:
               `force_include_range` are all mutually exclusive. Users
               should supply value(s) for exactly one of these arguments.
 
+            By default, ``None``.
         exclude_range : list | tuple, optional
             Two-item list of (min threshold, max threshold) for values
             to exclude. Mutually exclusive with other inputs - see info

--- a/reV/supply_curve/sc_aggregation.py
+++ b/reV/supply_curve/sc_aggregation.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=anomalous-backslash-in-string
 """reV supply curve aggregation framework.
 
 Created on Fri Jun 21 13:24:31 2019

--- a/reV/supply_curve/sc_aggregation.py
+++ b/reV/supply_curve/sc_aggregation.py
@@ -278,7 +278,14 @@ class SupplyCurveAggregation(BaseAggregation):
             Filepath to HDF5 file with ``reV`` econ output results
             containing an `lcoe_dset` dataset. If ``None``, `lcoe_dset`
             should be a dataset in the `gen_fpath` HDF5 file that
-            aggregation is executed on. By default, ``None``.
+            aggregation is executed on. If running ``reV`` from the
+            command line, this input can be set to ``"PIPELINE"``, which
+            will parse this input from the following pipeline steps:
+            `multi-year`, `collect`, and `generation`. However, note
+            that duplicate executions of any of these commands within
+            the pipeline may invalidate this parsing, meaning the
+            `econ_fpath` input will have to be specified manually.
+            By default, ``None``.
         excl_dict : dict | None
             Dictionary of exclusion keyword arguments of the format
             ``{layer_dset_name: {kwarg: value}}``, where
@@ -1295,8 +1302,14 @@ class SupplyCurveAggregation(BaseAggregation):
         gen_fpath : str, optional
             Filepath to HDF5 file with ``reV`` generation output
             results. If ``None``, a simple aggregation without any
-            generation, resource, or cost data is performed.
-            By default, ``None``.
+            generation, resource, or cost data is performed. If running
+            ``reV`` from the command line, this input can be set to
+            ``"PIPELINE"``, which will parse this input from the
+            following pipeline steps: `multi-year`, `collect`, and
+            `econ`. However, note that duplicate executions of any of
+            these commands within the pipeline may invalidate this
+            parsing, meaning the `econ_fpath` input will have to be
+            specified manually. By default, ``None``.
         res_fpath : str, optional
             Filepath to HDF5 resource file (e.g. WTK or NSRDB). This
             input is required if techmap dset is to be created or if

--- a/reV/supply_curve/sc_aggregation.py
+++ b/reV/supply_curve/sc_aggregation.py
@@ -269,23 +269,28 @@ class SupplyCurveAggregation(BaseAggregation):
               techmap must be used for every unique combination of
               resource and exclusion coordinates.
 
-            If running ``reV`` from the command line, you can specify a
-            name that is not in the exclusions HDF5 file, and ``reV``
-            will calculate the techmap for you. Note however that
-            computing the techmap and writing it to the exclusion HDF5
-            file is a blocking operation, so you may only run a single
-            ``reV`` aggregation step at a time this way.
+            .. Note:: If executing ``reV`` from the command line, you
+              can specify a name that is not in the exclusions HDF5
+              file, and ``reV`` will calculate the techmap for you. Note
+              however that computing the techmap and writing it to the
+              exclusion HDF5 file is a blocking operation, so you may
+              only run a single ``reV`` aggregation step at a time this
+              way.
+
         econ_fpath : str, optional
             Filepath to HDF5 file with ``reV`` econ output results
             containing an `lcoe_dset` dataset. If ``None``, `lcoe_dset`
             should be a dataset in the `gen_fpath` HDF5 file that
-            aggregation is executed on. If running ``reV`` from the
-            command line, this input can be set to ``"PIPELINE"``, which
-            will parse this input from the following pipeline steps:
-            `multi-year`, `collect`, and `generation`. However, note
-            that duplicate executions of any of these commands within
-            the pipeline may invalidate this parsing, meaning the
-            `econ_fpath` input will have to be specified manually.
+            aggregation is executed on.
+
+            .. Note:: If executing ``reV`` from the command line, this
+              input can be set to ``"PIPELINE"`` to parse the output
+              from one of these preceding pipeline steps:
+              ``multi-year``, ``collect``, or ``generation``. However,
+              note that duplicate executions of any of these commands
+              within the pipeline may invalidate this parsing, meaning
+              the `econ_fpath` input will have to be specified manually.
+
             By default, ``None``.
         excl_dict : dict | None
             Dictionary of exclusion keyword arguments of the format
@@ -1303,14 +1308,17 @@ class SupplyCurveAggregation(BaseAggregation):
         gen_fpath : str, optional
             Filepath to HDF5 file with ``reV`` generation output
             results. If ``None``, a simple aggregation without any
-            generation, resource, or cost data is performed. If running
-            ``reV`` from the command line, this input can be set to
-            ``"PIPELINE"``, which will parse this input from the
-            following pipeline steps: `multi-year`, `collect`, and
-            `econ`. However, note that duplicate executions of any of
-            these commands within the pipeline may invalidate this
-            parsing, meaning the `econ_fpath` input will have to be
-            specified manually. By default, ``None``.
+            generation, resource, or cost data is performed.
+
+            .. Note:: If executing ``reV`` from the command line, this
+              input can be set to ``"PIPELINE"`` to parse the output
+              from one of these preceding pipeline steps:
+              ``multi-year``, ``collect``, or ``econ``. However, note
+              that duplicate executions of any of these commands within
+              the pipeline may invalidate this parsing, meaning the
+              `econ_fpath` input will have to be specified manually.
+
+            By default, ``None``.
         res_fpath : str, optional
             Filepath to HDF5 resource file (e.g. WTK or NSRDB). This
             input is required if techmap dset is to be created or if

--- a/reV/supply_curve/supply_curve.py
+++ b/reV/supply_curve/supply_curve.py
@@ -52,10 +52,16 @@ class SupplyCurve:
             Path to CSV or JSON or DataFrame containing supply curve
             point summary. Can also be a filepath to a ``reV`` bespoke
             HDF5 output file where the ``meta`` dataset has the same
-            format as the supply curve aggregation output. If running
-            ``reV`` from the command line, this input can also be
-            ``"PIPELINE"`` to parse the output of the previous step and
-            use it as input to this call.
+            format as the supply curve aggregation output.
+
+            .. Note:: If executing ``reV`` from the command line, this
+              input can also be ``"PIPELINE"`` to parse the output of
+              the previous pipeline step and use it as input to this
+              call. However, note that duplicate executions of any
+              preceding commands within the pipeline may invalidate this
+              parsing, meaning the `sc_points` input will have to be
+              specified manually.
+
         trans_table : str | pandas.DataFrame | list
             Path to CSV or JSON or DataFrame containing supply curve
             transmission mapping. This can also be a list of

--- a/reV/utilities/cli_functions.py
+++ b/reV/utilities/cli_functions.py
@@ -103,8 +103,7 @@ def parse_from_pipeline(config, out_dir, config_key, target_modules):
                 target_key = "gen_fpath"
             else:
                 target_key = "out_file"
-            val = Status.parse_command_status(out_dir, target_module,
-                                              target_key)
+            val = Status.parse_step_status(out_dir, target_module, target_key)
             if len(val) == 1:
                 break
         else:

--- a/reV/version.py
+++ b/reV/version.py
@@ -2,4 +2,4 @@
 reV Version number
 """
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-NREL-gaps>=0.4.5
+NREL-gaps>=0.5.0
 NREL-NRWAL>=0.0.7
 NREL-PySAM~=4.1.0
 NREL-rex>=0.2.80

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-NREL-gaps>=0.5.0
+NREL-gaps>=0.6.0
 NREL-NRWAL>=0.0.7
 NREL-PySAM~=4.1.0
 NREL-rex>=0.2.80


### PR DESCRIPTION
Upgrade to GAPs v0.6.0, including minor update to docs to include new commands and some updated function calls.

Also updated reVX install to match the reVX repo (HOPP team pushed incompatible version causing tests to fail)