### PR TITLE
Generation `max_workers` defaults to `None` if omitted from config file

### DIFF
--- a/reV/generation/cli_gen.py
+++ b/reV/generation/cli_gen.py
@@ -43,6 +43,7 @@ def _preprocessor(config, job_name, log_directory, verbose,
         Updated config file.
     """
     init_cli_logging(job_name, log_directory, verbose)
+    config.get("execution_control", {}).setdefault("max_workers")
     analysis_years = format_analysis_years(analysis_years)
 
     config["resource_file"] = _parse_res_files(config["resource_file"],

--- a/reV/generation/generation.py
+++ b/reV/generation/generation.py
@@ -782,7 +782,10 @@ class Gen(BaseGen):
             module name and/or resource data year will get added to the
             output file name. By default, ``None``.
         max_workers : int, optional
-            Number of local workers to run on. By default, ``1``.
+            Number of local workers to run on. If ``None``, or if
+            running from the command line and omitting this argument
+            from your config file completely, this input is set to
+            ``os.cpu_count()``. Otherwise, the default is ``1``.
         timeout : int, optional
             Number of seconds to wait for parallel run iteration to
             complete before returning zeros. By default, ``1800``

--- a/tests/test_gen_config.py
+++ b/tests/test_gen_config.py
@@ -17,6 +17,7 @@ import traceback
 
 from reV.cli import main
 from reV.config.project_points import ProjectPoints
+from reV.generation.base import BaseGen
 from reV.generation.generation import Gen
 from reV import TESTDATADIR
 from reV.handlers.outputs import Outputs
@@ -179,6 +180,49 @@ def test_sam_config(tech):
                "not match".format(tech))
         assert np.allclose(gen_json.out['cf_profile'],
                            gen_dict.out['cf_profile']), msg
+
+
+@pytest.mark.parametrize('expected_log_message',
+                         ["Running serial generation for",
+                          "Running parallel generation for"])
+def test_gen_mw_config_input(runner, clear_loggers, expected_log_message):
+    """Test max_workers input from gen config"""
+    with tempfile.TemporaryDirectory() as td:
+
+        run_dir = os.path.join(td, 'generation')
+        os.mkdir(run_dir)
+        project_points = os.path.join(TESTDATADIR, 'config', '..',
+                                      'config', "wtk_pp_2012_10.csv")
+        resource_file = os.path.join(TESTDATADIR, 'wtk/ri_100_wtk_{}.h5')
+        sam_files = {"wind0":
+                     os.path.join(TESTDATADIR,
+                                  "SAM/wind_gen_standard_losses_0.json")}
+
+        config = os.path.join(TESTDATADIR, 'config', 'local_wind.json')
+        config = safe_json_load(config)
+        if "parallel" in expected_log_message:
+            config["execution_control"].pop("max_workers")
+        else:
+            config["execution_control"]["max_workers"] = 1
+
+        config['project_points'] = project_points
+        config['resource_file'] = resource_file
+        config['sam_files'] = sam_files
+        config['log_directory'] = run_dir
+
+        config_path = os.path.join(run_dir, 'config.json')
+        with open(config_path, 'w') as f:
+            json.dump(config, f)
+
+        result = runner.invoke(main, ['generation', '-c', config_path])
+        msg = ('Failed with error {}'
+               .format(traceback.print_exception(*result.exc_info)))
+        assert result.exit_code == 0, msg
+
+        log_file = os.path.join(run_dir, 'generation_generation.log')
+        with open(log_file, "r") as fh:
+            assert expected_log_message in fh.read()
+        clear_loggers()
 
 
 def execute_pytest(capture='all', flags='-rapP'):

--- a/tests/test_gen_config.py
+++ b/tests/test_gen_config.py
@@ -17,7 +17,6 @@ import traceback
 
 from reV.cli import main
 from reV.config.project_points import ProjectPoints
-from reV.generation.base import BaseGen
 from reV.generation.generation import Gen
 from reV import TESTDATADIR
 from reV.handlers.outputs import Outputs


### PR DESCRIPTION
Mostly a QOL change - it has no impact if the user explicitly specifies `max_workers` in their config file. However, if the user _omits_ this input from their config file altogether, the default value is set to `None` instead of `1`. The default value for the API is still `1`.