### PR TITLE
Bespoke turbine location bug fixes

### DIFF
--- a/reV/bespoke/place_turbines.py
+++ b/reV/bespoke/place_turbines.py
@@ -151,7 +151,7 @@ class PlaceTurbines:
         nx, ny = np.shape(self.include_mask)
         self.safe_polygons = MultiPolygon()
         side_x = np.arange(nx + 1) * self.pixel_side_length
-        side_y = np.arange(ny + 1, -1, -1) * self.pixel_side_length
+        side_y = np.arange(ny, -1, -1) * self.pixel_side_length
         floored = np.floor(self.include_mask)
         for i in range(nx):
             for j in range(ny):

--- a/reV/supply_curve/points.py
+++ b/reV/supply_curve/points.py
@@ -357,13 +357,11 @@ class SupplyCurvePoint(AbstractSupplyCurvePoint):
         centroid : tuple
             SC point centroid (lat, lon).
         """
-        decimals = 3
 
         if self._centroid is None:
             lats = self.exclusions.excl_h5['latitude', self.rows, self.cols]
             lons = self.exclusions.excl_h5['longitude', self.rows, self.cols]
-            self._centroid = (np.round(lats.mean(), decimals=decimals),
-                              np.round(lons.mean(), decimals=decimals))
+            self._centroid = (lats.mean(), lons.mean())
 
         return self._centroid
 

--- a/reV/version.py
+++ b/reV/version.py
@@ -2,4 +2,4 @@
 reV Version number
 """
 
-__version__ = "0.8.5"
+__version__ = "0.8.6"


### PR DESCRIPTION
Remove lat/lon rounding and fix annoying bespoke bug that reported turbines 90m too far in the y direction.