### PR TITLE
Report scaled capital cost in output supply curve

### DIFF
--- a/reV/supply_curve/points.py
+++ b/reV/supply_curve/points.py
@@ -1585,6 +1585,9 @@ class GenerationSupplyCurvePoint(AggregationSupplyCurvePoint):
                 if all(k in self.mean_h5_dsets_data for k in required):
                     aep = (self.mean_h5_dsets_data['system_capacity']
                            * self.mean_cf * 8760)
+                    # Note the AEP computation uses the SAM config
+                    # `system_capacity`, so no need to scale `capital_cost`
+                    # or `fixed_operating_cost` by anything
                     mean_lcoe = lcoe_fcr(
                         self.mean_h5_dsets_data['fixed_charge_rate'],
                         self.mean_h5_dsets_data['capital_cost'],

--- a/reV/supply_curve/points.py
+++ b/reV/supply_curve/points.py
@@ -1802,14 +1802,16 @@ class GenerationSupplyCurvePoint(AggregationSupplyCurvePoint):
 
         This method scales the capital cost based on the included-area
         capacity. The calculation requires 'capital_cost' and
-        'system_capacity' in the generation file, otherwise it returns
-        `None`.
+        'system_capacity' in the generation file and passed through as
+        `h5_dsets`, otherwise it returns `None`.
 
         Returns
         -------
         sc_point_capital_cost : float | None
             Total supply curve point capital cost ($).
         """
+        if self.mean_h5_dsets_data is None:
+            return None
 
         required = ('capital_cost', 'system_capacity')
         if not all(k in self.mean_h5_dsets_data for k in required):
@@ -1826,13 +1828,16 @@ class GenerationSupplyCurvePoint(AggregationSupplyCurvePoint):
         This method scales the fixed operating cost based on the
         included-area capacity. The calculation requires
         'fixed_operating_cost' and 'system_capacity' in the generation
-        file, otherwise it returns `None`.
+        file and passed through as `h5_dsets`, otherwise it returns
+        `None`.
 
         Returns
         -------
         sc_point_fixed_operating_cost : float | None
             Total supply curve point fixed operating cost ($).
         """
+        if self.mean_h5_dsets_data is None:
+            return None
 
         required = ('fixed_operating_cost', 'system_capacity')
         if not all(k in self.mean_h5_dsets_data for k in required):

--- a/reV/supply_curve/points.py
+++ b/reV/supply_curve/points.py
@@ -1980,6 +1980,7 @@ class GenerationSupplyCurvePoint(AggregationSupplyCurvePoint):
         summary['raw_lcoe'] = eos.raw_lcoe
         summary['mean_lcoe'] = eos.scaled_lcoe
         summary['capital_cost_scalar'] = eos.capital_cost_scalar
+        summary['scaled_capital_cost'] = eos.scaled_capital_cost
 
         return summary
 

--- a/reV/version.py
+++ b/reV/version.py
@@ -2,4 +2,4 @@
 reV Version number
 """
 
-__version__ = "0.8.6"
+__version__ = "0.8.7"

--- a/tests/test_econ_of_scale.py
+++ b/tests/test_econ_of_scale.py
@@ -162,6 +162,8 @@ def test_econ_of_scale_baseline():
         sc_df = pd.read_csv(out_fp_sc + ".csv")
         assert np.allclose(base_df['mean_lcoe'], sc_df['mean_lcoe'])
         assert (sc_df['capital_cost_scalar'] == 1).all()
+        assert np.allclose(sc_df['mean_capital_cost'],
+                           sc_df['scaled_capital_cost'])
 
 
 def test_sc_agg_econ_scale():
@@ -225,6 +227,8 @@ def test_sc_agg_econ_scale():
                             / aep + data['variable_operating_cost'])
 
         assert np.allclose(scalars, sc_df['capital_cost_scalar'])
+        assert np.allclose(scalars * sc_df['mean_capital_cost'],
+                           sc_df['scaled_capital_cost'])
 
         assert np.allclose(true_scaled_lcoe, sc_df['mean_lcoe'])
         assert np.allclose(true_raw_lcoe, sc_df['raw_lcoe'])

--- a/tests/test_supply_curve_sc_aggregation.py
+++ b/tests/test_supply_curve_sc_aggregation.py
@@ -110,6 +110,7 @@ def test_agg_summary():
 
         summary = summary.fillna('None')
         s_baseline = s_baseline.fillna('None')
+        summary = summary[list(s_baseline.columns)]
 
         assert_frame_equal(summary, s_baseline, check_dtype=False, rtol=0.0001)
 
@@ -205,6 +206,7 @@ def test_pre_extract_inclusions(pre_extract):
 
         summary = summary.fillna('None')
         s_baseline = s_baseline.fillna('None')
+        summary = summary[list(s_baseline.columns)]
 
         assert_frame_equal(summary, s_baseline, check_dtype=False, rtol=0.0001)
 


### PR DESCRIPTION
When specifying an EOS curve, we were reporting the EOS multiplier and the scaled LCOE but not the scaled capital cost. This PR now also outputs the scaled capital cost value in the SC, which is needed for downstream models like ReEDS.

Also report cost values and annual energy for each supply curve based on its capacity.