### PR TITLE
Fix gen output file name if year in directory

### DIFF
--- a/reV/generation/base.py
+++ b/reV/generation/base.py
@@ -881,9 +881,10 @@ class BaseGen(ABC):
             out_fn = out_fn.replace(".h5", extension_with_module)
 
         # ensure year is in out_fpath
-        if self.year is not None and str(self.year) not in out_fn:
+        if self.year is not None:
             extension_with_year = "_{}.h5".format(self.year)
-            out_fn = out_fn.replace(".h5", extension_with_year)
+            if extension_with_year not in out_fn:
+                out_fn = out_fn.replace(".h5", extension_with_year)
 
         # create and use optional output dir
         if project_dir and not os.path.exists(project_dir):

--- a/reV/generation/base.py
+++ b/reV/generation/base.py
@@ -1135,6 +1135,7 @@ class BaseGen(ABC):
                      .format(len(pc_chunks), [len(x) for x in pc_chunks]))
         return N, pc_chunks
 
+    # pylint: disable=unused-argument
     def _reduce_kwargs(self, pc, **kwargs):
         """Placeholder for functions that need to reduce the global kwargs that
         they send to workers to reduce memory footprint

--- a/tests/test_gen_config.py
+++ b/tests/test_gen_config.py
@@ -224,6 +224,43 @@ def test_gen_mw_config_input(runner, clear_loggers, expected_log_message):
         clear_loggers()
 
 
+def test_year_in_dir_name(runner, clear_loggers):
+    """Test generation run with year in project dir"""
+    with tempfile.TemporaryDirectory() as td:
+
+        run_dir = os.path.join(td, 'generation_2012_2013')
+        os.mkdir(run_dir)
+        project_points = os.path.join(TESTDATADIR, 'config', '..',
+                                      'config', "wtk_pp_2012_10.csv")
+        resource_file = os.path.join(TESTDATADIR, 'wtk/ri_100_wtk_{}.h5')
+        sam_files = {"wind0":
+                     os.path.join(TESTDATADIR,
+                                  "SAM/wind_gen_standard_losses_0.json")}
+
+        config = os.path.join(TESTDATADIR, 'config', 'local_wind.json')
+        config = safe_json_load(config)
+
+        config['project_points'] = project_points
+        config['resource_file'] = resource_file
+        config['sam_files'] = sam_files
+        config['log_directory'] = run_dir
+        config["analysis_years"] = [2012, 2013]
+
+        config_path = os.path.join(run_dir, 'config.json')
+        with open(config_path, 'w') as f:
+            json.dump(config, f)
+
+        result = runner.invoke(main, ['generation', '-c', config_path])
+        msg = ('Failed with error {}'
+               .format(traceback.print_exception(*result.exc_info)))
+        assert result.exit_code == 0, msg
+
+        h5_files = [fn for fn in os.listdir(run_dir)
+                    if "generation_2012_2013" in fn and ".h5" in fn]
+        assert len(h5_files) == 2
+        clear_loggers()
+
+
 def execute_pytest(capture='all', flags='-rapP'):
     """Execute module as pytest with detailed summary report.
 


### PR DESCRIPTION
Previously, year would be omitted if it's in the project directory, which caused issues for the collection step. Basically, we are avoiding the following situation with this change: 

![image](https://github.com/NREL/reV/assets/28815465/813aec42-bd9e-4870-b7f0-51e478f385d7)
