### PR TITLE
PySAM upgrade to 5.1

### DIFF
--- a/reV/version.py
+++ b/reV/version.py
@@ -2,4 +2,4 @@
 reV Version number
 """
 
-__version__ = "0.8.8"
+__version__ = "0.8.9"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 NREL-gaps>=0.6.11
 NREL-NRWAL>=0.0.7
-NREL-PySAM~=4.1.0
+NREL-PySAM~=5.1.0
 NREL-rex>=0.2.85
 packaging>=20.3
 plotly>=4.7.1


### PR DESCRIPTION
Open for access to GHA tests

This PR will also fix code to run with numpy 2.0.0 +