### PR TITLE
Add BOS cost to bespoke optimization

### DIFF
--- a/reV/bespoke/bespoke.py
+++ b/reV/bespoke/bespoke.py
@@ -1336,7 +1336,7 @@ class BespokeSinglePlant:
         )
         self._meta["bespoke_balance_of_system_cost"] = (
             self.plant_optimizer.balance_of_system_cost
-            )
+        )
         self._meta["included_area"] = self.plant_optimizer.area
         self._meta["included_area_capacity_density"] = (
             self.plant_optimizer.capacity_density

--- a/reV/bespoke/bespoke.py
+++ b/reV/bespoke/bespoke.py
@@ -236,6 +236,10 @@ class BespokeSinglePlant:
                 - ``avg_sl_dist_to_medoid_m``: Average straight-line
                   distance to the medoid of all turbine locations
                   (in m). Useful for computing plant BOS costs.
+                - ``nn_conn_dist_m``: Total BOS connection distance
+                  using nearest-neighbor connections. This variable is
+                  only available for the
+                  ``balance_of_system_cost_function`` equation.
                 - ``fixed_charge_rate``: user input fixed_charge_rate if
                   included as part of the sam system config.
                 - ``capital_cost``: plant capital cost as evaluated
@@ -1204,6 +1208,7 @@ class BespokeSinglePlant:
             self.plant_optimizer.avg_sl_dist_to_center_m
         self._meta["avg_sl_dist_to_medoid_m"] = \
             self.plant_optimizer.avg_sl_dist_to_medoid_m
+        self._meta["nn_conn_dist_m"] = self.plant_optimizer.nn_conn_dist_m
         self._meta["bespoke_aep"] = self.plant_optimizer.aep
         self._meta["bespoke_objective"] = self.plant_optimizer.objective
         self._meta["bespoke_capital_cost"] = \
@@ -1390,6 +1395,10 @@ class BespokeWindPlants(BaseAggregation):
                 - ``avg_sl_dist_to_medoid_m``: Average straight-line
                   distance to the medoid of all turbine locations
                   (in m). Useful for computing plant BOS costs.
+                - ``nn_conn_dist_m``: Total BOS connection distance
+                  using nearest-neighbor connections. This variable is
+                  only available for the
+                  ``balance_of_system_cost_function`` equation.
                 - ``fixed_charge_rate``: user input fixed_charge_rate if
                   included as part of the sam system config.
                 - ``capital_cost``: plant capital cost as evaluated

--- a/reV/bespoke/bespoke.py
+++ b/reV/bespoke/bespoke.py
@@ -1205,8 +1205,6 @@ class BespokeSinglePlant:
         self._meta["avg_sl_dist_to_medoid_m"] = \
             self.plant_optimizer.avg_sl_dist_to_medoid_m
         self._meta["bespoke_aep"] = self.plant_optimizer.aep
-        self._meta["bespoke_avg_sl_dist_to_center_m"] = \
-            self.plant_optimizer.avg_sl_dist_to_center_m
         self._meta["bespoke_objective"] = self.plant_optimizer.objective
         self._meta["bespoke_capital_cost"] = \
             self.plant_optimizer.capital_cost

--- a/reV/bespoke/cli_bespoke.py
+++ b/reV/bespoke/cli_bespoke.py
@@ -54,6 +54,8 @@ def _log_bespoke_cli_inputs(config):
                 .format(config.get("fixed_operating_cost_function")))
     logger.info('Bespoke variable operating cost function: "{}"'
                 .format(config.get("variable_operating_cost_function")))
+    logger.info('Bespoke balance of system cost function: "{}"'
+                .format(config.get("balance_of_system_cost_function")))
     logger.info('Bespoke wake loss multiplier: "{}"'
                 .format(config.get("wake_loss_multiplier", 1)))
     logger.info('The following project points were specified: "{}"'

--- a/reV/bespoke/place_turbines.py
+++ b/reV/bespoke/place_turbines.py
@@ -75,6 +75,10 @@ class PlaceTurbines:
                 - ``avg_sl_dist_to_medoid_m``: Average straight-line
                   distance to the medoid of all turbine locations
                   (in m). Useful for computing plant BOS costs.
+                - ``nn_conn_dist_m``: Total BOS connection distance
+                  using nearest-neighbor connections. This variable is
+                  only available for the
+                  ``balance_of_system_cost_function`` equation.
                 - ``fixed_charge_rate``: user input fixed_charge_rate if
                   included as part of the sam system config.
                 - ``capital_cost``: plant capital cost as evaluated
@@ -149,6 +153,7 @@ class PlaceTurbines:
         self.packing_polygons = None
         self.optimized_design_variables = None
         self.safe_polygons = None
+        self._optimized_nn_conn_dist_m = None
 
         self.ILLEGAL = ('import ', 'os.', 'sys.', '.__', '__.', 'eval', 'exec')
         self._preflight(self.objective_function)
@@ -268,9 +273,12 @@ class PlaceTurbines:
             aep = self._aep_after_scaled_wake_losses()
             avg_sl_dist_to_center_m = self._avg_sl_dist_to_cent(x_locs, y_locs)
             avg_sl_dist_to_medoid_m = self._avg_sl_dist_to_med(x_locs, y_locs)
+            if "nn_conn_dist_m" in self.balance_of_system_cost_function:
+                nn_conn_dist_m = _compute_nn_conn_dist(x_locs, y_locs)
         else:
             n_turbines = system_capacity = aep = 0
             avg_sl_dist_to_center_m = avg_sl_dist_to_medoid_m = 0
+            nn_conn_dist_m = 0
 
         fixed_charge_rate = self.fixed_charge_rate
         capital_cost = eval(self.capital_cost_function,
@@ -438,6 +446,16 @@ class PlaceTurbines:
 
     @property
     @none_until_optimized
+    def nn_conn_dist_m(self):
+        """This is the final avg straight line distance to turb medoid (m)"""
+        if self._optimized_nn_conn_dist_m is None:
+            self._optimized_nn_conn_dist_m = _compute_nn_conn_dist(
+                self.turbine_x, self.turbine_y
+            )
+        return self._optimized_nn_conn_dist_m
+
+    @property
+    @none_until_optimized
     def nturbs(self):
         """This is the final optimized number of turbines"""
         return np.sum(self.optimized_design_variables)
@@ -536,6 +554,8 @@ class PlaceTurbines:
         aep = self.aep
         avg_sl_dist_to_center_m = self.avg_sl_dist_to_center_m
         avg_sl_dist_to_medoid_m = self.avg_sl_dist_to_medoid_m
+        nn_conn_dist_m = self.nn_conn_dist_m
+
         mult = self.wind_plant.sam_sys_inputs.get(
             'capital_cost_multiplier', 1)
         return eval(self.capital_cost_function, globals(), locals()) * mult
@@ -552,6 +572,8 @@ class PlaceTurbines:
         aep = self.aep
         avg_sl_dist_to_center_m = self.avg_sl_dist_to_center_m
         avg_sl_dist_to_medoid_m = self.avg_sl_dist_to_medoid_m
+        nn_conn_dist_m = self.nn_conn_dist_m
+
         mult = self.wind_plant.sam_sys_inputs.get(
             'fixed_operating_cost_multiplier', 1)
         return eval(self.fixed_operating_cost_function,
@@ -569,6 +591,8 @@ class PlaceTurbines:
         aep = self.aep
         avg_sl_dist_to_center_m = self.avg_sl_dist_to_center_m
         avg_sl_dist_to_medoid_m = self.avg_sl_dist_to_medoid_m
+        nn_conn_dist_m = self.nn_conn_dist_m
+
         mult = self.wind_plant.sam_sys_inputs.get(
             'variable_operating_cost_multiplier', 1)
         return eval(self.variable_operating_cost_function,
@@ -584,6 +608,8 @@ class PlaceTurbines:
         aep = self.aep
         avg_sl_dist_to_center_m = self.avg_sl_dist_to_center_m
         avg_sl_dist_to_medoid_m = self.avg_sl_dist_to_medoid_m
+        nn_conn_dist_m = self.nn_conn_dist_m
+
         mult = self.wind_plant.sam_sys_inputs.get(
             'balance_of_system_cost_multiplier', 1)
         return eval(self.balance_of_system_cost_function,
@@ -604,9 +630,40 @@ class PlaceTurbines:
         balance_of_system_cost = self.balance_of_system_cost
         avg_sl_dist_to_center_m = self.avg_sl_dist_to_center_m
         avg_sl_dist_to_medoid_m = self.avg_sl_dist_to_medoid_m
+        nn_conn_dist_m = self.nn_conn_dist_m
+
         return eval(self.objective_function, globals(), locals())
 
 
 def _turb_medoid(x_locs, y_locs):
     """Turbine medoid. """
     return np.median(x_locs), np.median(y_locs)
+
+
+def _compute_nn_conn_dist(x_coords, y_coords):
+    """Connect turbines using a greedy nearest-neighbor approach. """
+    if len(x_coords) <= 1:
+        return 0
+
+    coordinates = np.c_[x_coords, y_coords]
+    allowed_conns = np.r_[coordinates.mean(axis=0)[None], coordinates]
+
+    mask = np.zeros_like(allowed_conns)
+    mask[0] = 1
+    left_to_connect = np.ma.array(allowed_conns, mask=mask)
+
+    mask = np.ones_like(allowed_conns)
+    mask[0] = 0
+    allowed_conns = np.ma.array(allowed_conns, mask=mask)
+
+    total_dist = 0
+    for __ in range(len(coordinates)):
+        dists = left_to_connect[:, :, None] - allowed_conns.T[None]
+        dists = np.hypot(dists[:, 0], dists[:, 1])
+        min_dists = dists.min(axis=-1)
+        total_dist += min_dists.min()
+        next_connection = min_dists.argmin()
+        allowed_conns.mask[next_connection] = 0
+        left_to_connect.mask[next_connection] = 1
+
+    return total_dist

--- a/reV/bespoke/place_turbines.py
+++ b/reV/bespoke/place_turbines.py
@@ -49,6 +49,7 @@ class PlaceTurbines:
                  capital_cost_function,
                  fixed_operating_cost_function,
                  variable_operating_cost_function,
+                 balance_of_system_cost_function,
                  include_mask, pixel_side_length, min_spacing,
                  wake_loss_multiplier=1):
         """
@@ -64,26 +65,29 @@ class PlaceTurbines:
             should return the objective to be minimized during layout
             optimization. Variables available are:
 
-                - n_turbines: the number of turbines
-                - system_capacity: wind plant capacity
-                - aep: annual energy production
-                - avg_sl_dist_to_center_m: Average straight-line
+                - ``n_turbines``: the number of turbines
+                - ``system_capacity``: wind plant capacity
+                - ``aep``: annual energy production
+                - ``avg_sl_dist_to_center_m``: Average straight-line
                   distance to the supply curve point center from all
                   turbine locations (in m). Useful for computing plant
                   BOS costs.
-                - fixed_charge_rate: user input fixed_charge_rate if
+                - ``avg_sl_dist_to_medoid_m``: Average straight-line
+                  distance to the medoid of all turbine locations
+                  (in m). Useful for computing plant BOS costs.
+                - ``fixed_charge_rate``: user input fixed_charge_rate if
                   included as part of the sam system config.
-                - capital_cost: plant capital cost as evaluated
+                - ``capital_cost``: plant capital cost as evaluated
                   by `capital_cost_function`
-                - fixed_operating_cost: plant fixed annual operating
+                - ``fixed_operating_cost``: plant fixed annual operating
                   cost as evaluated by `fixed_operating_cost_function`
-                - variable_operating_cost: plant variable annual
+                - ``variable_operating_cost``: plant variable annual
                   operating cost as evaluated by
                   `variable_operating_cost_function`
-                - self.wind_plant: the SAM wind plant object, through
-                  which all SAM variables can be accessed
-                - cost: the annual cost of the wind plant (from
-                  cost_function)
+                - ``balance_of_system_cost``: plant balance of system
+                  cost as evaluated by `balance_of_system_cost_function`
+                - ``self.wind_plant``: the SAM wind plant object,
+                  through which all SAM variables can be accessed
 
         capital_cost_function : str
             The plant capital cost function as a string, must return the
@@ -97,6 +101,13 @@ class PlaceTurbines:
             The plant annual variable operating cost function as a
             string, must return the variable operating cost in $/kWh.
             Has access to the same variables as the objective_function.
+            You can set this to "0" to effectively ignore variable
+            operating costs.
+        balance_of_system_cost_function : str
+            The plant balance-of-system cost function as a string, must
+            return the variable operating cost in $. Has access to the
+            same variables as the objective_function. You can set this
+            to "0" to effectively ignore balance-of-system costs.
         include_mask : np.ndarray
             Supply curve point 2D inclusion mask where included pixels
             are set to 1 and excluded pixels are set to 0.
@@ -119,6 +130,7 @@ class PlaceTurbines:
         self.fixed_operating_cost_function = fixed_operating_cost_function
         self.variable_operating_cost_function = \
             variable_operating_cost_function
+        self.balance_of_system_cost_function = balance_of_system_cost_function
 
         self.objective_function = objective_function
         self.include_mask = include_mask
@@ -143,6 +155,7 @@ class PlaceTurbines:
         self._preflight(self.capital_cost_function)
         self._preflight(self.fixed_operating_cost_function)
         self._preflight(self.variable_operating_cost_function)
+        self._preflight(self.balance_of_system_cost_function)
 
     def _preflight(self, eqn):
         """Run preflight checks on the equation string."""
@@ -219,11 +232,21 @@ class PlaceTurbines:
         self.x_locations = packing.turbine_x
         self.y_locations = packing.turbine_y
 
-    def _avg_sl_dist_to_cent(self, x_locs, y_locs):
-        """Average straight-line distance to center from turb locations. """
+    def _sc_center(self):
+        """Supply curve point center. """
         ny, nx = np.shape(self.include_mask)
         cx = nx * self.pixel_side_length / 2
         cy = ny * self.pixel_side_length / 2
+        return cx, cy
+
+    def _avg_sl_dist_to_cent(self, x_locs, y_locs):
+        """Average straight-line distance to center from turb locations. """
+        cx, cy = self._sc_center()
+        return np.hypot(x_locs - cx, y_locs - cy).mean()
+
+    def _avg_sl_dist_to_med(self, x_locs, y_locs):
+        """Average straight-line distance to turbine medoid. """
+        cx, cy = _turb_medoid(x_locs, y_locs)
         return np.hypot(x_locs - cx, y_locs - cy).mean()
 
     # pylint: disable=W0641,W0123
@@ -244,8 +267,10 @@ class PlaceTurbines:
             self.wind_plant.execute()
             aep = self._aep_after_scaled_wake_losses()
             avg_sl_dist_to_center_m = self._avg_sl_dist_to_cent(x_locs, y_locs)
+            avg_sl_dist_to_medoid_m = self._avg_sl_dist_to_med(x_locs, y_locs)
         else:
-            n_turbines = system_capacity = aep = avg_sl_dist_to_center_m = 0
+            n_turbines = system_capacity = aep = 0
+            avg_sl_dist_to_center_m = avg_sl_dist_to_medoid_m = 0
 
         fixed_charge_rate = self.fixed_charge_rate
         capital_cost = eval(self.capital_cost_function,
@@ -254,13 +279,16 @@ class PlaceTurbines:
                                     globals(), locals())
         variable_operating_cost = eval(self.variable_operating_cost_function,
                                        globals(), locals())
-
+        balance_of_system_cost = eval(self.balance_of_system_cost_function,
+                                      globals(), locals())
         capital_cost *= self.wind_plant.sam_sys_inputs.get(
             'capital_cost_multiplier', 1)
         fixed_operating_cost *= self.wind_plant.sam_sys_inputs.get(
             'fixed_operating_cost_multiplier', 1)
         variable_operating_cost *= self.wind_plant.sam_sys_inputs.get(
             'variable_operating_cost_multiplier', 1)
+        balance_of_system_cost *= self.wind_plant.sam_sys_inputs.get(
+            'balance_of_system_cost_multiplier', 1)
 
         objective = eval(self.objective_function, globals(), locals())
 
@@ -371,6 +399,7 @@ class PlaceTurbines:
         """
 
         fixed_charge_rate = self.fixed_charge_rate
+        avg_sl_dist_to_center_m = self.avg_sl_dist_to_center_m
         n_turbines = int(round(capacity_mw * 1e3 / self.turbine_capacity))
         system_capacity = n_turbines * self.turbine_capacity
         mult = self.wind_plant.sam_sys_inputs.get(
@@ -499,6 +528,7 @@ class PlaceTurbines:
         n_turbines = self.nturbs
         system_capacity = self.capacity
         aep = self.aep
+        avg_sl_dist_to_center_m = self.avg_sl_dist_to_center_m
         mult = self.wind_plant.sam_sys_inputs.get(
             'capital_cost_multiplier', 1)
         return eval(self.capital_cost_function, globals(), locals()) * mult
@@ -513,6 +543,7 @@ class PlaceTurbines:
         n_turbines = self.nturbs
         system_capacity = self.capacity
         aep = self.aep
+        avg_sl_dist_to_center_m = self.avg_sl_dist_to_center_m
         mult = self.wind_plant.sam_sys_inputs.get(
             'fixed_operating_cost_multiplier', 1)
         return eval(self.fixed_operating_cost_function,
@@ -528,9 +559,24 @@ class PlaceTurbines:
         n_turbines = self.nturbs
         system_capacity = self.capacity
         aep = self.aep
+        avg_sl_dist_to_center_m = self.avg_sl_dist_to_center_m
         mult = self.wind_plant.sam_sys_inputs.get(
             'variable_operating_cost_multiplier', 1)
         return eval(self.variable_operating_cost_function,
+                    globals(), locals()) * mult
+
+    @property
+    @none_until_optimized
+    def balance_of_system_cost(self):
+        """This is the balance of system cost of the optimized plant ($)"""
+        fixed_charge_rate = self.fixed_charge_rate
+        n_turbines = self.nturbs
+        system_capacity = self.capacity
+        aep = self.aep
+        avg_sl_dist_to_center_m = self.avg_sl_dist_to_center_m
+        mult = self.wind_plant.sam_sys_inputs.get(
+            'balance_of_system_cost_multiplier', 1)
+        return eval(self.balance_of_system_cost_function,
                     globals(), locals()) * mult
 
     # pylint: disable=W0641,W0123
@@ -545,5 +591,11 @@ class PlaceTurbines:
         capital_cost = self.capital_cost
         fixed_operating_cost = self.fixed_operating_cost
         variable_operating_cost = self.variable_operating_cost
+        balance_of_system_cost = self.balance_of_system_cost
         avg_sl_dist_to_center_m = self.avg_sl_dist_to_center_m
         return eval(self.objective_function, globals(), locals())
+
+
+def _turb_medoid(x_locs, y_locs):
+    """Turbine medoid. """
+    return np.median(x_locs), np.median(y_locs)

--- a/reV/bespoke/place_turbines.py
+++ b/reV/bespoke/place_turbines.py
@@ -432,6 +432,12 @@ class PlaceTurbines:
 
     @property
     @none_until_optimized
+    def avg_sl_dist_to_medoid_m(self):
+        """This is the final avg straight line distance to turb medoid (m)"""
+        return self._avg_sl_dist_to_med(self.turbine_x, self.turbine_y)
+
+    @property
+    @none_until_optimized
     def nturbs(self):
         """This is the final optimized number of turbines"""
         return np.sum(self.optimized_design_variables)
@@ -529,6 +535,7 @@ class PlaceTurbines:
         system_capacity = self.capacity
         aep = self.aep
         avg_sl_dist_to_center_m = self.avg_sl_dist_to_center_m
+        avg_sl_dist_to_medoid_m = self.avg_sl_dist_to_medoid_m
         mult = self.wind_plant.sam_sys_inputs.get(
             'capital_cost_multiplier', 1)
         return eval(self.capital_cost_function, globals(), locals()) * mult
@@ -544,6 +551,7 @@ class PlaceTurbines:
         system_capacity = self.capacity
         aep = self.aep
         avg_sl_dist_to_center_m = self.avg_sl_dist_to_center_m
+        avg_sl_dist_to_medoid_m = self.avg_sl_dist_to_medoid_m
         mult = self.wind_plant.sam_sys_inputs.get(
             'fixed_operating_cost_multiplier', 1)
         return eval(self.fixed_operating_cost_function,
@@ -560,6 +568,7 @@ class PlaceTurbines:
         system_capacity = self.capacity
         aep = self.aep
         avg_sl_dist_to_center_m = self.avg_sl_dist_to_center_m
+        avg_sl_dist_to_medoid_m = self.avg_sl_dist_to_medoid_m
         mult = self.wind_plant.sam_sys_inputs.get(
             'variable_operating_cost_multiplier', 1)
         return eval(self.variable_operating_cost_function,
@@ -574,6 +583,7 @@ class PlaceTurbines:
         system_capacity = self.capacity
         aep = self.aep
         avg_sl_dist_to_center_m = self.avg_sl_dist_to_center_m
+        avg_sl_dist_to_medoid_m = self.avg_sl_dist_to_medoid_m
         mult = self.wind_plant.sam_sys_inputs.get(
             'balance_of_system_cost_multiplier', 1)
         return eval(self.balance_of_system_cost_function,
@@ -593,6 +603,7 @@ class PlaceTurbines:
         variable_operating_cost = self.variable_operating_cost
         balance_of_system_cost = self.balance_of_system_cost
         avg_sl_dist_to_center_m = self.avg_sl_dist_to_center_m
+        avg_sl_dist_to_medoid_m = self.avg_sl_dist_to_medoid_m
         return eval(self.objective_function, globals(), locals())
 
 

--- a/tests/test_bespoke.py
+++ b/tests/test_bespoke.py
@@ -699,6 +699,7 @@ def test_consistent_eval_namespace(gid=33):
     cap_cost_fun = "2000"
     foc_fun = "0"
     voc_fun = "0"
+    bos_fun = "0"
     objective_function = (
         "n_turbines + id(self.wind_plant) "
         "+ system_capacity + capital_cost + aep"
@@ -722,6 +723,7 @@ def test_consistent_eval_namespace(gid=33):
             cap_cost_fun,
             foc_fun,
             voc_fun,
+            bos_fun,
             ga_kwargs={"max_time": 5},
             excl_dict=EXCL_DICT,
             output_request=output_request,

--- a/tests/test_bespoke.py
+++ b/tests/test_bespoke.py
@@ -913,6 +913,21 @@ def test_bespoke_wind_plant_with_power_curve_losses():
                                  BOS_FUN,
                                  excl_dict=EXCL_DICT,
                                  output_request=output_request)
+        optimizer2 = bsp.plant_optimizer
+        optimizer2.wind_plant["wind_farm_xCoordinates"] = [1000, -1000]
+        optimizer2.wind_plant["wind_farm_yCoordinates"] = [1000, -1000]
+        cap = 2 * optimizer2.turbine_capacity
+        optimizer2.wind_plant["system_capacity"] = cap
+
+        optimizer2.wind_plant.assign_inputs()
+        optimizer2.wind_plant.execute()
+        aep_losses = optimizer2._aep_after_scaled_wake_losses()
+        bsp.close()
+
+    assert aep > aep_losses, f"{aep}, {aep_losses}"
+
+    err_msg = "{:0.3f} != 0.9".format(aep_losses / aep)
+    assert np.isclose(aep_losses / aep, 0.9), err_msg
 
 
 def test_bespoke_run_with_power_curve_losses():

--- a/tests/test_bespoke.py
+++ b/tests/test_bespoke.py
@@ -273,6 +273,7 @@ def test_packing_algorithm(gid=33):
     cap_cost_fun = ""
     foc_fun = ""
     voc_fun = ""
+    bos_fun = ""
     objective_function = ""
     with tempfile.TemporaryDirectory() as td:
         res_fp = os.path.join(td, "ri_100_wtk_{}.h5")
@@ -293,6 +294,7 @@ def test_packing_algorithm(gid=33):
             cap_cost_fun,
             foc_fun,
             voc_fun,
+            bos_fun,
             ga_kwargs={"max_time": 5},
             excl_dict=EXCL_DICT,
             output_request=output_request,

--- a/tests/test_bespoke.py
+++ b/tests/test_bespoke.py
@@ -891,6 +891,7 @@ def test_bespoke_wind_plant_with_power_curve_losses():
 
         optimizer.wind_plant.assign_inputs()
         optimizer.wind_plant.execute()
+        # pylint: disable=W0612
         aep = optimizer._aep_after_scaled_wake_losses()
         bsp.close()
 
@@ -908,7 +909,6 @@ def test_bespoke_wind_plant_with_power_curve_losses():
                                  BOS_FUN,
                                  excl_dict=EXCL_DICT,
                                  output_request=output_request)
-
 
 
 def test_bespoke_run_with_power_curve_losses():


### PR DESCRIPTION
This PR adds the capability to specify a BOS cost for the bespoke optimization.

Three distances are allowed: `avg_sl_dist_to_center_m`, `avg_sl_dist_to_medoid_m`, and `nn_conn_dist_m`. The first two are self-explanatory. The last one is a simple greedy nearest-neighbor connection algorithm that gives connections that look something like this:

![image](https://github.com/NREL/reV/assets/28815465/a84b29be-8295-4016-8623-5a5daa2d453a)
