### PR TITLE
Add resource length warning for easier debugging

### DIFF
--- a/reV/SAM/generation.py
+++ b/reV/SAM/generation.py
@@ -234,11 +234,10 @@ class AbstractSamGeneration(RevPySam, ScheduledLossesMixin, ABC):
             raise InputError(msg)
 
         if len(resource) < 8760:
-            msg = (f"Detected resource time series of length "
-                   f"{len(resource)}, which is less than 8760. This may "
-                   f"yeild unexpected results or fail altogether. If this "
-                   f"is not intentional, try setting 'time_index_step: 1' "
-                   f"in your SAM config")
+            msg = (f"Detected resource time series of length {len(resource)}, "
+                   "which is less than 8760. This may yield unexpected "
+                   "results or fail altogether. If this is not intentional, "
+                   "try setting 'time_index_step: 1' in your SAM config")
             logger.warning(msg)
             warn(msg)
 

--- a/reV/SAM/generation.py
+++ b/reV/SAM/generation.py
@@ -237,7 +237,8 @@ class AbstractSamGeneration(RevPySam, ScheduledLossesMixin, ABC):
             msg = (f"Detected resource time series of length {len(resource)}, "
                    "which is less than 8760. This may yield unexpected "
                    "results or fail altogether. If this is not intentional, "
-                   "try setting 'time_index_step: 1' in your SAM config")
+                   "try setting 'time_index_step: 1' in your SAM config or "
+                   "double check the resource input you're using.")
             logger.warning(msg)
             warn(msg)
 

--- a/reV/SAM/generation.py
+++ b/reV/SAM/generation.py
@@ -860,8 +860,6 @@ class AbstractSamSolar(AbstractSamGeneration, ABC):
                 time_index, resource.pop("albedo")
             )
 
-        pd.DataFrame(resource).to_csv("/scratch/ppinchuk/test_pvwatts.csv", index=False)
-
         self["solar_resource_data"] = resource
 
 

--- a/reV/SAM/generation.py
+++ b/reV/SAM/generation.py
@@ -233,6 +233,15 @@ class AbstractSamGeneration(RevPySam, ScheduledLossesMixin, ABC):
             logger.error(msg)
             raise InputError(msg)
 
+        if len(resource) < 8760:
+            msg = (f"Detected resource time series of length "
+                   f"{len(resource)}, which is less than 8760. This may "
+                   f"yeild unexpected results or fail altogether. If this "
+                   f"is not intentional, try setting 'time_index_step: 1' "
+                   f"in your SAM config")
+            logger.warning(msg)
+            warn(msg)
+
     @abstractmethod
     def set_resource_data(self, resource, meta):
         """Placeholder for resource data setting (nsrdb or wtk)"""
@@ -850,6 +859,8 @@ class AbstractSamSolar(AbstractSamGeneration, ABC):
             self["albedo"] = self.agg_albedo(
                 time_index, resource.pop("albedo")
             )
+
+        pd.DataFrame(resource).to_csv("/scratch/ppinchuk/test_pvwatts.csv", index=False)
 
         self["solar_resource_data"] = resource
 

--- a/reV/bespoke/bespoke.py
+++ b/reV/bespoke/bespoke.py
@@ -912,6 +912,15 @@ class BespokeSinglePlant:
                 ti_step = self.original_sam_sys_inputs["time_index_step"]
                 self._res_df = self._res_df.iloc[::ti_step]
 
+        if len(self._res_df) < 8760:
+            msg = (f"Detected resource time series of length "
+                   f"{len(self._res_df)}, which is less than 8760. This may "
+                   f"yeild unexpected results or fail altogether. If this "
+                   f"is not intentional, try setting 'time_index_step: 1' "
+                   f"in your SAM config")
+            logger.warning(msg)
+            warn(msg)
+
         return self._res_df
 
     @property

--- a/reV/bespoke/bespoke.py
+++ b/reV/bespoke/bespoke.py
@@ -912,15 +912,6 @@ class BespokeSinglePlant:
                 ti_step = self.original_sam_sys_inputs["time_index_step"]
                 self._res_df = self._res_df.iloc[::ti_step]
 
-        if len(self._res_df) < 8760:
-            msg = (f"Detected resource time series of length "
-                   f"{len(self._res_df)}, which is less than 8760. This may "
-                   f"yeild unexpected results or fail altogether. If this "
-                   f"is not intentional, try setting 'time_index_step: 1' "
-                   f"in your SAM config")
-            logger.warning(msg)
-            warn(msg)
-
         return self._res_df
 
     @property


### PR DESCRIPTION
@grantbuster Reid recently ran into a tough-to-debug issue where SAM wasn't setting the output variables correctly, and it came down to the fact that he was using `time_index_step=2` on hourly resource data.

Since this was a tough problem to track down, I figured I would add a few warning messages if this case is detected. Any objections? Any reason why someone would want to run less than a full 8760 time series through SAM? Is that even allowed (seems like not based on this experience but I haven't fully tested that)?