### PR TITLE
Fix zero cost EOS bug

### DIFF
--- a/reV/econ/economies_of_scale.py
+++ b/reV/econ/economies_of_scale.py
@@ -278,7 +278,7 @@ class EconomiesOfScale:
             Fixed operating cost from input data arg
         """
         foc_from_cap = self._cost_from_cap(
-            SupplyCurveField.COST_BASE_FOC_USD_PER_AC_MW
+            SupplyCurveField.COST_SITE_FOC_USD_PER_AC_MW
         )
         if foc_from_cap is not None:
             return foc_from_cap
@@ -297,7 +297,7 @@ class EconomiesOfScale:
             Variable operating cost from input data arg
         """
         voc_from_cap = self._cost_from_cap(
-            SupplyCurveField.COST_BASE_VOC_USD_PER_AC_MW
+            SupplyCurveField.COST_SITE_VOC_USD_PER_AC_MW
         )
         if voc_from_cap is not None:
             return voc_from_cap

--- a/reV/econ/economies_of_scale.py
+++ b/reV/econ/economies_of_scale.py
@@ -212,11 +212,7 @@ class EconomiesOfScale:
         if cost_per_mw is None:
             return None
 
-        cost = cap * cost_per_mw
-        if cost > 0:
-            return cost
-
-        return None
+        return cap * cost_per_mw
 
     @property
     def raw_capital_cost(self):

--- a/reV/supply_curve/points.py
+++ b/reV/supply_curve/points.py
@@ -2188,10 +2188,10 @@ class GenerationSupplyCurvePoint(AggregationSupplyCurvePoint):
     def _compute_cost_per_ac_mw(self, dset):
         """Compute a cost per AC MW for a given input. """
         if self._sam_system_capacity <= 0:
-            return 0
+            return None
 
         if dset not in self.gen.datasets:
-            return 0
+            return None
 
         sam_cost = self.exclusion_weighted_mean(self.gen[dset])
         sam_cost_per_mw = sam_cost / self._sam_system_capacity

--- a/reV/supply_curve/points.py
+++ b/reV/supply_curve/points.py
@@ -2391,10 +2391,11 @@ class GenerationSupplyCurvePoint(AggregationSupplyCurvePoint):
         summary[SupplyCurveField.RAW_LCOE] = eos.raw_lcoe
         summary[SupplyCurveField.MEAN_LCOE] = eos.scaled_lcoe
         summary[SupplyCurveField.EOS_MULT] = eos.capital_cost_scalar
-        summary[SupplyCurveField.COST_SITE_OCC_USD_PER_AC_MW] = (
-            summary[SupplyCurveField.COST_SITE_OCC_USD_PER_AC_MW]
-            * summary[SupplyCurveField.EOS_MULT]
-        )
+        cost = summary[SupplyCurveField.COST_SITE_OCC_USD_PER_AC_MW]
+        if cost is not None:
+            summary[SupplyCurveField.COST_SITE_OCC_USD_PER_AC_MW] = (
+                cost * summary[SupplyCurveField.EOS_MULT]
+            )
         return summary
 
     @classmethod

--- a/reV/version.py
+++ b/reV/version.py
@@ -2,4 +2,4 @@
 reV Version number
 """
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"


### PR DESCRIPTION
Refactor left a bug that would crash program if any LCOE component is set to 0 (like VOC usually is). New default cost is `None` (NaN), which allows 0 values to pass through normally