### PR TITLE
Fix regional cost bug

### DIFF
--- a/reV/SAM/SAM.py
+++ b/reV/SAM/SAM.py
@@ -927,6 +927,9 @@ class RevPySam(Sam):
 
 def _add_cost_defaults(sam_inputs):
     """Add default values for required cost outputs if they are missing. """
+    if sam_inputs.get("__already_added_cost_defaults"):
+        return
+
     sam_inputs.setdefault("fixed_charge_rate", None)
 
     reg_mult = sam_inputs.setdefault("capital_cost_multiplier", 1)
@@ -942,6 +945,8 @@ def _add_cost_defaults(sam_inputs):
         sam_inputs["capital_cost"] = capital_cost * reg_mult
     else:
         sam_inputs["capital_cost"] = None
+
+    sam_inputs["__already_added_cost_defaults"] = True
 
 
 def _add_sys_capacity(sam_inputs):

--- a/reV/version.py
+++ b/reV/version.py
@@ -2,4 +2,4 @@
 reV Version number
 """
 
-__version__ = "0.9.4"
+__version__ = "0.9.5"

--- a/tests/test_econ_lcoe.py
+++ b/tests/test_econ_lcoe.py
@@ -272,7 +272,7 @@ def test_capital_cost_multiplier_regional(clear_loggers):
         num = (cc * sam_config["fixed_charge_rate"]
                + sam_config["fixed_operating_cost"])
         aep = cf * sam_config["system_capacity"] / 1000 * 8760
-        lcoe_truth = num / aep + sam_config["variable_operating_cost"]
+        lcoe_truth = num / aep + sam_config["variable_operating_cost"] * 1000
 
         assert np.allclose(lcoe, lcoe_truth, rtol=RTOL, atol=ATOL)
         clear_loggers()


### PR DESCRIPTION
Previously, regional multipliers would be applied twice - once during the generation run and once during the econ run. We need the econ data to be formalized at generation run time though, for output collection purposes. So, in this PR, I added a flag that let's reV know if econ values have already been adjusted. If so, no other adjustments are made.

A test for regional multipliers did exist, but it was only on the econ module. This bug happens when generation and econ are both run so this bug slipped through the cracks. I added a new test that checks the multipliers for a combined generation + econ run