### PR TITLE
Fix MY handler regression

### DIFF
--- a/reV/handlers/multi_year.py
+++ b/reV/handlers/multi_year.py
@@ -96,14 +96,15 @@ class MultiYearGroup:
         pass_through_dsets : list
             List of pass through datasets.
         """
+        with Resource(self.source_files[0]) as res:
+            all_dsets = res.datasets
+
         if isinstance(dsets, str) and dsets == 'PIPELINE':
-            files = parse_previous_status(self._dirout, ModuleName.MULTI_YEAR)
-            with Resource(files[0]) as res:
-                dsets = res.datasets
+            dsets = all_dsets
 
         if "lcoe_fcr" in dsets:
             for dset in LCOE_REQUIRED_OUTPUTS:
-                if dset not in pass_through_dsets and dset in dsets:
+                if dset not in pass_through_dsets and dset in all_dsets:
                     pass_through_dsets.append(dset)
 
         if "dc_ac_ratio" in dsets:


### PR DESCRIPTION
If user defines "dsets" in MY collection config as a subset of all possible dsets, then some required LCOE dsets may end up missing from the output (i.e. not added to `pass_through_dsets`). In this PR, we pull the full set of available datasets regardless of the user input. Includes test.