### PR TITLE
Gb/revs3

### DIFF
--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -19,12 +19,12 @@ jobs:
             python-version: 3.8
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.ref }}
         fetch-depth: 1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/s3_tests.yml
+++ b/.github/workflows/s3_tests.yml
@@ -1,0 +1,31 @@
+name: s3 fsspec tests
+
+on: pull_request
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.10"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+          python -m pip install .[s3]
+      - name: Run pytest and Generate coverage report
+        shell: bash
+        run: |
+          pytest -v tests/s3_tests.py

--- a/.github/workflows/s3_tests.yml
+++ b/.github/workflows/s3_tests.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 1
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -28,4 +31,4 @@ jobs:
       - name: Run pytest and Generate coverage report
         shell: bash
         run: |
-          pytest -v tests/s3_tests.py
+          python -m pytest -v tests/s3_tests.py --disable-warnings

--- a/README.rst
+++ b/README.rst
@@ -126,8 +126,11 @@ Option 1: Install from PIP (recommended for analysts):
 3. Install reV:
     1) ``pip install NREL-reV`` or
 
+       - NOTE: If you install using conda and want to run from files directly on S3 like in the `running reV locally example <https://nrel.github.io/reV/misc/examples.running_locally.html>`_
+         you will also need to install S3 filesystem dependencies: ``pip install NREL-reV[s3]``
+
        - NOTE: If you install using conda and want to use `HSDS <https://github.com/NREL/hsds-examples>`_
-         you will also need to install h5pyd manually: ``pip install h5pyd``
+         you will also need to install HSDS dependencies: ``pip install NREL-reV[hsds]``
 
 Option 2: Clone repo (recommended for developers)
 -------------------------------------------------

--- a/examples/aws_pcluster/config_gen.json
+++ b/examples/aws_pcluster/config_gen.json
@@ -8,8 +8,7 @@
     "nodes": 16,
     "option": "slurm",
     "sites_per_worker": 20,
-    "max_workers": 1,
-    "sh_script": "sh ~/start_hsds.sh"
+    "max_workers": 1
   },
   "log_level": "INFO",
   "output_request": [
@@ -18,7 +17,10 @@
     "lcoe_fcr"
   ],
   "project_points": "./wtk_points_front_range.csv",
-  "resource_file": "/nrel/wtk/conus/wtk_conus_{}.h5",
+  "resource_file": [
+      "s3://nrel-pds-wtk/conus/v1.0.0/wtk_conus_2007.h5",
+      "s3://nrel-pds-wtk/conus/v1.0.0/wtk_conus_2008.h5"
+  ],
   "sam_files": {
     "def": "./windpower.json"
   },

--- a/examples/running_locally/README.rst
+++ b/examples/running_locally/README.rst
@@ -5,7 +5,7 @@ Run reV locally
 and `reV Econ <https://nrel.github.io/reV/_autosummary/reV.econ.econ.Econ.html#reV.econ.econ.Econ>`_
 can be run locally using resource .h5 files stored locally.
 
-For users outside of NREL: you can now point reV directly to filepaths on S3! This will stream small amounts of data from S3 directly to your computer without having to setup an IO server like HSDS. See the example for reading data directly from S3 `here <https://nrel.github.io/rex/misc/examples.fsspec.html>`_ and try the example below with resource file paths from S3. 
+For users outside of NREL: you can now point reV directly to filepaths on S3! This will stream small amounts of data from S3 directly to your computer without having to setup an IO server like HSDS. See the example for reading data directly from S3 `here <https://nrel.github.io/rex/misc/examples.fsspec.html>`_ and try the example below with resource file paths from S3. You will need to do an extra install ``pip install NREL-reV[s3]``.
 
 reV Gen
 -------
@@ -23,17 +23,19 @@ coordinates:
 .. code-block:: python
 
     import os
+    import numpy as np
     from reV import TESTDATADIR
     from reV.config.project_points import ProjectPoints
     from reV.generation.generation import Gen
 
     lat_lons = np.array([[ 41.25, -71.66],
-                            [ 41.05, -71.74],
-                            [ 41.97, -71.78],
-                            [ 41.65, -71.74],
-                            [ 41.25, -71.7 ],
-                            [ 41.05, -71.78]])
+                         [ 41.05, -71.74],
+                         [ 41.97, -71.78],
+                         [ 41.65, -71.74],
+                         [ 41.25, -71.7 ],
+                         [ 41.05, -71.78]])
 
+    # res_file could also be 's3://nrel-pds-wtk/conus/v1.0.0/wtk_conus_2007.h5'
     res_file = os.path.join(TESTDATADIR, 'wtk/ri_100_wtk_2012.h5')
     sam_file = os.path.join(TESTDATADIR,
                              'SAM/wind_gen_standard_losses_0.json')
@@ -68,6 +70,7 @@ Compute pvcapacity factors for all resource gids in a Rhode Island:
 
     regions = {'Rhode Island': 'state'}
 
+    # res_file could also be 's3://nrel-pds-nsrdb/current/nsrdb_2018.h5'
     res_file = os.path.join(TESTDATADIR, 'nsrdb/', 'ri_100_nsrdb_2012.h5')
     sam_file = os.path.join(TESTDATADIR, 'SAM/naris_pv_1axis_inv13.json')
 

--- a/examples/running_with_hsds/README.rst
+++ b/examples/running_with_hsds/README.rst
@@ -11,7 +11,11 @@ You can use the NREL developer API as the HSDS endpoint for small workloads
 or stand up your own HSDS local server (instructions further below) for an
 enhanced parallelized data experience.
 
+For general information on where to get started accessing NREL data from outside of NREL, see the `rex docs <https://nrel.github.io/rex/misc/examples.nrel_data.html#data-location-external-users>`_.
+
 You might also be interested in these examples of how to set up your own `local HSDS server <https://nrel.github.io/rex/misc/examples.hsds.html#setting-up-a-local-hsds-server>`_ and how to run reV on an `AWS parallel cluster <https://nrel.github.io/reV/misc/examples.aws_pcluster.html>`_.
+
+Note that running directly from S3 files will be an easier solution although not as performant. For more details on running directly from S3 files see `running reV locally <https://nrel.github.io/reV/misc/examples.running_locally.html>`_ and the `rex s3 example <https://nrel.github.io/rex/misc/examples.fsspec.html>`_
 
 Setting up HSDS
 ---------------

--- a/reV/version.py
+++ b/reV/version.py
@@ -2,4 +2,4 @@
 reV Version number
 """
 
-__version__ = "0.9.6"
+__version__ = "0.9.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 NREL-gaps>=0.6.11
 NREL-NRWAL>=0.0.7
 NREL-PySAM~=4.1.0
-NREL-rex>=0.2.89
+NREL-rex>=0.2.97
 numpy~=1.24.4
 packaging>=20.3
 plotly>=4.7.1

--- a/setup.py
+++ b/setup.py
@@ -106,6 +106,8 @@ setup(
     extras_require={
         "test": test_requires,
         "dev": test_requires + ["flake8", "pre-commit", "pylint"],
+        "s3": ['fsspec', 's3fs'],
+        "hsds": ["hsds>=0.8.4"],
     },
     cmdclass={"develop": PostDevelopCommand},
 )

--- a/tests/s3_tests.py
+++ b/tests/s3_tests.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+"""
+PyTest file wind generation directly from s3 file
+
+Note that this directly tests the example here:
+    https://nrel.github.io/reV/misc/examples.running_locally.html
+
+Note that this file cannot be named "test_*.py" because it is run with a
+separate github action that sets up a local hsds server before running the
+test.
+"""
+
+import os
+import numpy as np
+from reV import TESTDATADIR
+from reV.config.project_points import ProjectPoints
+from reV.generation.generation import Gen
+
+
+def test_windpower_s3():
+    lat_lons = np.array([[41.25, -71.66]])
+
+    res_file = 's3://nrel-pds-wtk/conus/v1.0.0/wtk_conus_2007.h5'
+    sam_file = os.path.join(TESTDATADIR, 'SAM/wind_gen_standard_losses_0.json')
+
+    pp = ProjectPoints.lat_lon_coords(lat_lons, res_file, sam_file)
+    gen = Gen('windpower', pp, sam_file, res_file,
+              output_request=('cf_mean', 'cf_profile'))
+    gen.run(max_workers=1)
+
+    assert isinstance(gen.out['cf_profile'], np.ndarray)
+    assert gen.out['cf_profile'].sum() > 0


### PR DESCRIPTION
Enables reV to run directly from filepaths on s3 without HSDS setup. Will be less performant but will require zero setup. Also updated examples and included a test. 