### PR TITLE
Spatial curtailment

### DIFF
--- a/reV/SAM/SAM.py
+++ b/reV/SAM/SAM.py
@@ -190,7 +190,10 @@ class SamResourceRetriever:
             kwargs["icing"] = project_points.sam_config_obj.icing
             if (
                 project_points.curtailment is not None
-                and project_points.curtailment.precipitation
+                and any(
+                    config.precipitation
+                    for config in project_points.curtailment.values()
+                )
             ):
                 # make precip rate available for curtailment analysis
                 kwargs["precip_rate"] = True

--- a/reV/SAM/generation.py
+++ b/reV/SAM/generation.py
@@ -543,6 +543,8 @@ class AbstractSamGeneration(RevPySam, ScheduledLossesMixin, ABC):
         if curtailment is not None:
             for curtail_type, curtail_config in curtailment.items():
                 curtail_sites = points.get_sites_from_curtailment(curtail_type)
+                if not curtail_sites:
+                    continue
                 resources = curtail(resources, curtail_config, curtail_sites,
                                     random_seed=curtail_config.random_seed)
 

--- a/reV/config/project_points.py
+++ b/reV/config/project_points.py
@@ -690,18 +690,29 @@ class ProjectPoints:
 
         Returns
         -------
-        curtailments : NoneType | reV.config.curtailment.Curtailment
-            None if no curtailment, reV curtailment config object if
-            curtailment is being assessed.
+        curtailments : NoneType | dict
+            None if no curtailment, dictionary of reV curtailment config
+            objects if curtailment is being assessed.
         """
-        if isinstance(curtailment_input, (str, dict)):
-            # pointer to config file or explicit input namespace,
-            # instantiate curtailment config object
-            curtailment = Curtailment(curtailment_input)
+        if curtailment_input is None:
+            return None
 
-        elif isinstance(curtailment_input, (Curtailment, type(None))):
-            # pre-initialized curtailment object or no curtailment (None)
-            curtailment = curtailment_input
+        if isinstance(curtailment_input, str):
+            # pointer to config file - instantiate curtailment config
+            # object under default key
+            curtailment = {
+                _DEFAULT_CURTAIL_KEY: Curtailment(curtailment_input)}
+
+        elif isinstance(curtailment_input, dict):
+            # pointer to dict of configs - instantiate all
+            # curtailment config objects
+            curtailment = {k: Curtailment(v)
+                           for k, v in curtailment_input.items()}
+
+        elif isinstance(curtailment_input, Curtailment):
+            # pre-initialized curtailment object - instantiate
+            # curtailment config object under default key
+            curtailment = {_DEFAULT_CURTAIL_KEY: curtailment_input}
 
         else:
             curtailment = None

--- a/reV/config/project_points.py
+++ b/reV/config/project_points.py
@@ -532,10 +532,9 @@ class ProjectPoints:
 
         Parameters
         ----------
-        points : int | str | pd.DataFrame | slice | list
-            Slice specifying project points, string pointing to a project
-            points csv, or a dataframe containing the effective csv contents.
-            Can also be a single integer site value.
+        points : int | str | slice | list
+            Slice specifying project points, string pointing to a
+            project points csv. Can also be a single integer site value.
         res_file : str | NoneType
             Optional resource file to find maximum length of project points if
             points slice stop is None.

--- a/reV/config/project_points.py
+++ b/reV/config/project_points.py
@@ -830,9 +830,20 @@ class ProjectPoints:
             logger.error(msg)
             raise ConfigError(msg)
 
-        if len(df_configs) == 1 and df_configs[0] is None:
+        can_fill_null = (len(df_configs) == 1
+                         and df_configs[0] is None
+                         and len(curtail_configs) == 1)
+        if can_fill_null:
             self._df[SiteDataField.CURTAILMENT] = list(curtail_configs)[0]
             df_configs = self.df[SiteDataField.CURTAILMENT].unique()
+
+        unused_configs = set(curtail_configs) - set(df_configs)
+        if unused_configs:
+            msg = ("One or more curtailment configurations not found in "
+                   "project points and are thus ignored: {}"
+                   .format(unused_configs))
+            logger.warning(msg)
+            warn(msg, UserWarning)
 
         # Check to see if config references in project_points DataFrame
         # are valid file paths, if compare with curtailment configs

--- a/reV/config/project_points.py
+++ b/reV/config/project_points.py
@@ -913,6 +913,28 @@ class ProjectPoints:
 
         return list(sites)
 
+    def get_sites_from_curtailment(self, curtailment):
+        """Get a site list that corresponds to a curtailment key.
+
+        Parameters
+        ----------
+        curtailment : str
+            Curtailment configuration ID associated with sites.
+
+        Returns
+        -------
+        sites : list
+            List of sites associated with the requested curtailment ID.
+            If the curtailment ID is not recognized, an empty list is
+            returned.
+        """
+        sites = self.df.loc[
+            (self.df[SiteDataField.CURTAILMENT] == curtailment),
+            SiteDataField.GID
+        ].values
+
+        return list(sites)
+
     @classmethod
     def split(cls, i0, i1, project_points):
         """Return split instance of a ProjectPoints instance w/ site subset.

--- a/reV/config/project_points.py
+++ b/reV/config/project_points.py
@@ -818,9 +818,16 @@ class ProjectPoints:
         df_configs = self.df[SiteDataField.CURTAILMENT].unique()
         curtail_configs = self.curtailment
 
+        can_fill_null = (len(df_configs) == 1
+                         and df_configs[0] is None
+                         and len(curtail_configs) == 1)
+        if can_fill_null:
+            self._df[SiteDataField.CURTAILMENT] = list(curtail_configs)[0]
+            df_configs = self.df[SiteDataField.CURTAILMENT].unique()
+
         # Checks to make sure that the same number of curtailment config
         # files as references in project_points DataFrame
-        if len(df_configs) > len(curtail_configs):
+        if len(set(df_configs) - {None}) > len(curtail_configs):
             msg = (
                 "Points references {} curtailment configs while only "
                 "{} curtailment configs were provided!".format(
@@ -830,12 +837,6 @@ class ProjectPoints:
             logger.error(msg)
             raise ConfigError(msg)
 
-        can_fill_null = (len(df_configs) == 1
-                         and df_configs[0] is None
-                         and len(curtail_configs) == 1)
-        if can_fill_null:
-            self._df[SiteDataField.CURTAILMENT] = list(curtail_configs)[0]
-            df_configs = self.df[SiteDataField.CURTAILMENT].unique()
 
         unused_configs = set(curtail_configs) - set(df_configs)
         if unused_configs:

--- a/reV/config/project_points.py
+++ b/reV/config/project_points.py
@@ -624,6 +624,10 @@ class ProjectPoints:
         if SiteDataField.CONFIG not in df.columns:
             df[SiteDataField.CONFIG] = None
 
+        # pylint: disable=no-member
+        if SiteDataField.CURTAILMENT not in df.columns:
+            df[SiteDataField.CURTAILMENT] = None
+
         gids = df[SiteDataField.GID].values
         if not np.array_equal(np.sort(gids), gids):
             msg = (

--- a/reV/generation/generation.py
+++ b/reV/generation/generation.py
@@ -352,9 +352,9 @@ class Gen(BaseGen):
         curtailment : dict | str, optional
             Inputs for curtailment parameters, which can be:
 
-                - Dictionary mapping curtailment "names" to strings
-                  (paths) or explicit namespaces of curtailment
-                  variables (dicts)
+                - Dictionary mapping curtailment "names" to A) strings
+                  (paths) or B) explicit namespaces of curtailment
+                  configurations (dicts)
                 - Single pointer to curtailment config file with path
                   (str). In this case, the curtailment config is given
                   a "default" name.

--- a/reV/generation/generation.py
+++ b/reV/generation/generation.py
@@ -350,14 +350,18 @@ class Gen(BaseGen):
 
             By default, ``None``.
         curtailment : dict | str, optional
-            Inputs for curtailment parameters, which can be:
+            Input for curtailment parameters, which can be one of:
 
-                - Dictionary mapping curtailment "names" to A) strings
-                  (paths) or B) explicit namespaces of curtailment
-                  configurations (dicts)
-                - Single pointer to curtailment config file with path
-                  (str). In this case, the curtailment config is given
-                  a "default" name.
+                - Single string representing path to curtailment config
+                  file. In this case, the curtailment config is given
+                  the name "default" and applied everywhere (if the
+                  project points "curtailment" column is missing or all
+                  ``None``) or only where the project points
+                  "curtailment" column contains a value of "default"
+                - Dictionary mapping user-defined curtailment "names" to
+                  either A) strings (paths) or B) explicit namespaces of
+                  curtailment configurations (dicts). Mixing these two
+                  _is_ allowed.
 
             The allowed key-value input pairs in the curtailment
             configuration are documented as properties of the

--- a/reV/generation/generation.py
+++ b/reV/generation/generation.py
@@ -175,12 +175,20 @@ class Gen(BaseGen):
 
                 - ``gid``: Integer specifying the generation GID of each
                   site.
-                - ``config``: Key in the `sam_files` input dictionary
+                - ``config``: This is an *optional* column that contains
+                  a key from the `sam_files` input dictionary
                   (see below) corresponding to the SAM configuration to
                   use for each particular site. This value can also be
-                  ``None`` (or left out completely) if you specify only
-                  a single SAM configuration file as the `sam_files`
-                  input.
+                  ``None``, ``"default"``, or left out completely if you
+                  specify only a single SAM configuration file as the
+                  `sam_files` input.
+                - ``curtailment``: This is an *optional* column that
+                  contains a key from the `curtailment` input dictionary
+                  (see below) corresponding to the curtailment to apply
+                  at that particular site. This value can also be
+                  ``None``, ``"default"``, or left out completely if you
+                  specify only a single curtailment configuration file
+                  as the `curtailment` input.
                 - ``capital_cost_multiplier``: This is an *optional*
                   multiplier input that, if included, will be used to
                   regionally scale the ``capital_cost`` input in the SAM
@@ -338,13 +346,20 @@ class Gen(BaseGen):
         curtailment : dict | str, optional
             Inputs for curtailment parameters, which can be:
 
-                - Explicit namespace of curtailment variables (dict)
-                - Pointer to curtailment config file with path (str)
+                - Dictionary mapping curtailment "names" to strings
+                  (paths) or explicit namespaces of curtailment
+                  variables (dicts)
+                - Single pointer to curtailment config file with path
+                  (str). In this case, the curtailment config is given
+                  a "default" name.
 
             The allowed key-value input pairs in the curtailment
             configuration are documented as properties of the
             :class:`reV.config.curtailment.Curtailment` class. If
-            ``None``, no curtailment is modeled. By default, ``None``.
+            ``None``, no curtailment is modeled. You can select which
+            curtailment gets applied to which site using the
+            "curtailment" column key in the project points input.
+            By default, ``None``.
         gid_map : dict | str, optional
             Mapping of unique integer generation gids (keys) to single
             integer resource gids (values). This enables unique

--- a/reV/generation/generation.py
+++ b/reV/generation/generation.py
@@ -246,9 +246,9 @@ class Gen(BaseGen):
             Filepath to resource data. This input can be path to a
             single resource HDF5 file or a path including a wildcard
             input like ``/h5_dir/prefix*suffix`` (i.e. if your datasets
-            for a single year are spread out over multiple files). In
-            all cases, the resource data must be readable by
-            :py:class:`rex.resource.Resource`
+            like wind speed, wind direction, pressure, and so on are
+            spread out over multiple files). In all cases, the resource
+            data must be readable by :py:class:`rex.resource.Resource`
             or :py:class:`rex.multi_file_resource.MultiFileResource`.
             (i.e. the resource data conform to the
             `rex data format <https://tinyurl.com/3fy7v5kx>`_). This
@@ -262,13 +262,19 @@ class Gen(BaseGen):
 
             .. Note:: If executing ``reV`` from the command line, this
               input string can contain brackets ``{}`` that will be
-              filled in by the `analysis_years` input. Alternatively,
-              this input can be a list of explicit files to process. In
-              this case, the length of the list must match the length of
-              the `analysis_years` input exactly, and the path are
-              assumed to align with the `analysis_years` (i.e. the first
-              path corresponds to the first analysis year, the second
-              path corresponds to the second analysis year, and so on).
+              filled in by the `analysis_years` input. If your datasets
+              span multiple files (e.g. "wtk_wind_speed_2012.h5",
+              "wtk_pressure_2012.h5", "wtk_wind_direction_2012.h5"), you
+              may use a wildcard input along with brackets, like so:
+              ``"wtk_*_{}.h5"``. Alternatively, this input can be a list
+              of explicit files to process. In this case, the length of
+              the list must match the length of the `analysis_years`
+              input exactly, and the paths are assumed to align with the
+              `analysis_years` (i.e. the first path corresponds to the
+              first analysis year, the second path corresponds to the
+              second analysis year, and so on). Wild cards are allowed,
+              even if you list out the years explicitly (i.e.
+              ``["wtk_*_2012.h5", "wtk_*_2013.h5", ...]``)
 
             .. Important:: If you are using custom resource data (i.e.
               not NSRDB/WTK/Sup3rCC, etc.), ensure the following:

--- a/reV/utilities/__init__.py
+++ b/reV/utilities/__init__.py
@@ -89,6 +89,7 @@ class SiteDataField(FieldEnum):
 
     GID = "gid"
     CONFIG = "config"
+    CURTAILMENT = "curtailment"
 
 
 class ResourceMetaField(FieldEnum):

--- a/reV/utilities/curtailment.py
+++ b/reV/utilities/curtailment.py
@@ -19,7 +19,7 @@ from rex.utilities.utilities import check_tz, get_lat_lon_cols
 logger = logging.getLogger(__name__)
 
 
-def curtail(resource, curtailment, random_seed=0):
+def curtail(resource, curtailment, sites, random_seed=0):
     """Curtail the SAM wind resource object based on project points.
 
     Parameters
@@ -28,6 +28,8 @@ def curtail(resource, curtailment, random_seed=0):
         SAM resource object for WIND resource.
     curtailment : reV.config.curtailment.Curtailment
         Curtailment config object.
+    sites : list
+        List of GID's to apply this curtailment to.
     random_seed : int | NoneType
         Number to seed the numpy random number generator. Used to generate
         reproducable psuedo-random results if the probability of curtailment
@@ -124,6 +126,6 @@ def curtail(resource, curtailment, random_seed=0):
         curtail_mult = np.where(mask, curtail_mult, 1)
 
     # Apply curtailment multiplier directly to resource
-    resource.curtail_windspeed(resource.sites, curtail_mult)
+    resource.curtail_windspeed(sites, curtail_mult)
 
     return resource

--- a/reV/utilities/curtailment.py
+++ b/reV/utilities/curtailment.py
@@ -43,7 +43,8 @@ def curtail(resource, curtailment, sites, random_seed=0):
         where curtailment is in effect.
     """
 
-    shape = resource.shape
+    shape = (resource.shape[0], len(sites))
+    site_pos = [resource.sites.index(id) for id in sites]
 
     # start with curtailment everywhere
     curtail_mult = np.zeros(shape)
@@ -76,10 +77,10 @@ def curtail(resource, curtailment, sites, random_seed=0):
         raise KeyError(msg)
 
     # Curtail resource when curtailment is possible and is nighttime
-    lat_lon_cols = get_lat_lon_cols(resource.meta)
-    solar_zenith_angle = SolarPosition(
-        resource.time_index,
-        resource.meta[lat_lon_cols].values).zenith
+    meta = resource["meta", sites]
+    lat_lon_cols = get_lat_lon_cols(meta)
+    solar_zenith_angle = SolarPosition(resource.time_index,
+                                       meta[lat_lon_cols].values).zenith
     mask = (solar_zenith_angle > curtailment.dawn_dusk)
     curtail_mult = np.where(mask, curtail_mult, 1)
 
@@ -94,28 +95,29 @@ def curtail(resource, curtailment, sites, random_seed=0):
                          list(resource._res_arrays.keys())),
                  HandlerWarning)
         else:
-            mask = (resource._res_arrays['precipitationrate']
+            mask = (resource._res_arrays['precipitationrate'][:, site_pos]
                     < curtailment.precipitation)
             curtail_mult = np.where(mask, curtail_mult, 1)
 
     # Curtail resource when curtailment is possible and temperature is high
     if curtailment.temperature is not None:
-        mask = (resource._res_arrays['temperature']
+        mask = (resource._res_arrays['temperature'][:, site_pos]
                 > curtailment.temperature)
         curtail_mult = np.where(mask, curtail_mult, 1)
 
     # Curtail resource when curtailment is possible and not that windy
     if curtailment.wind_speed is not None:
-        mask = (resource._res_arrays['windspeed']
+        mask = (resource._res_arrays['windspeed'][:, site_pos]
                 < curtailment.wind_speed)
         curtail_mult = np.where(mask, curtail_mult, 1)
 
     if curtailment.equation is not None:
         # pylint: disable=W0123,W0612
-        wind_speed = resource._res_arrays['windspeed']
-        temperature = resource._res_arrays['temperature']
+        wind_speed = resource._res_arrays['windspeed'][:, site_pos]
+        temperature = resource._res_arrays['temperature'][:, site_pos]
         if 'precipitationrate' in resource._res_arrays:
-            precipitation_rate = resource._res_arrays['precipitationrate']
+            precipitation_rate = (
+                resource._res_arrays['precipitationrate'][:, site_pos])
         mask = eval(curtailment.equation)
         curtail_mult = np.where(mask, curtail_mult, 1)
 

--- a/reV/version.py
+++ b/reV/version.py
@@ -2,4 +2,4 @@
 reV Version number
 """
 
-__version__ = "0.9.8"
+__version__ = "0.10.0"

--- a/reV/version.py
+++ b/reV/version.py
@@ -2,4 +2,4 @@
 reV Version number
 """
 
-__version__ = "0.9.7"
+__version__ = "0.9.8"

--- a/tests/test_curtailment.py
+++ b/tests/test_curtailment.py
@@ -61,7 +61,8 @@ def test_cf_curtailment(year, site):
         TESTDATADIR, "SAM/wind_gen_standard_losses_0.json"
     )
 
-    curtailment = os.path.join(TESTDATADIR, "config/", "curtailment.json")
+    curt_fn = "curtailment.json"
+    curtailment = os.path.join(TESTDATADIR, "config", curt_fn)
     points = slice(site, site + 1)
 
     # run reV 2.0 generation
@@ -76,7 +77,8 @@ def test_cf_curtailment(year, site):
         scale_outputs=True,
     )
     gen.run(max_workers=1)
-    results, check_curtailment = test_res_curtailment(year, site=site)
+    results, check_curtailment = test_res_curtailment(year, site=site,
+                                                      curt_fn=curt_fn)
     results["cf_profile"] = gen.out["cf_profile"].flatten()
 
     # was capacity factor NOT curtailed?
@@ -199,10 +201,12 @@ def test_random(year, site):
     assert diff <= 2, msg
 
 
-@pytest.mark.parametrize(("year", "site"), [("2012", 50), ("2013", 50)])
-def test_res_curtailment(year, site):
+@pytest.mark.parametrize("year", ["2012", "2013"])
+@pytest.mark.parametrize("site", [50])
+@pytest.mark.parametrize("curt_fn", ["curtailment.json"])
+def test_res_curtailment(year, site, curt_fn):
     """Test wind resource curtailment."""
-    out, non_curtailed_res, pp = get_curtailment(year)
+    out, non_curtailed_res, pp = get_curtailment(year, curt_fn=curt_fn)
     curtailment_config = list(pp.curtailment.values())[0]
 
     sza = SolarPosition(
@@ -325,7 +329,8 @@ def test_points_missing_curtailment():
     res_file = os.path.join(TESTDATADIR, "wtk/ri_100_wtk_2012.h5")
     sam_files = os.path.join(TESTDATADIR,
                              "SAM/wind_gen_standard_losses_0.json")
-    curtail_config = os.path.join(TESTDATADIR, "config/", "curtailment.json")
+    curt_fn = "curtailment.json"
+    curtail_config = os.path.join(TESTDATADIR, "config", curt_fn)
 
     curtailment = {"test_c1": curtail_config, "test_c2": curtail_config}
     points = slice(0, 1)
@@ -344,7 +349,7 @@ def test_points_missing_curtailment():
     for msg in expected_msgs:
         assert any(msg in str(record) for record in warn)
 
-    df, __ = test_res_curtailment(2012, 0)
+    df, __ = test_res_curtailment(2012, 0, curt_fn=curt_fn)
     assert np.allclose(gen.out["windspeed"][:, 0], df["original_wind"])
 
 


### PR DESCRIPTION
Refactor curtailment to allow spatially-explicit curtailment options via project points input. The new curtailment functions very similar to the SAM config input now. 

Unfortunately this minorly breaks the existing curtailment specification method. Namely, users could previously input the curtailment config directly like so:
```
"curtailment":  {
    "dawn_dusk": "nautical",
    "months": [4, 5, 6, 7],
    "probability": 1,
    "wind_speed": 10.0,
}
```

In the updated version, users will have to assign the configuration a name, like so:
```
"curtailment":  {
    "main_curtailment": {
        "dawn_dusk": "nautical",
        "months": [4, 5, 6, 7],
        "probability": 1,
        "wind_speed": 10.0,
    }
}
```

The latter allows specifying multiple curtailment configs (which is required to perform spatially-explicit curtailment:
```
"curtailment":  {
    "main_curtailment": {
        "dawn_dusk": "nautical",
        "months": [4, 5, 6, 7],
        "probability": 1,
        "wind_speed": 10.0,
    },
    "other_curtailment": "/path/to/other/curtailment.json"
}
```
