### PR TITLE
Remove s3 install instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,9 +126,6 @@ Option 1: Install from PIP (recommended for analysts):
 3. Install reV:
     1) ``pip install NREL-reV`` or
 
-       - NOTE: If you install using conda and want to run from files directly on S3 like in the `running reV locally example <https://nrel.github.io/reV/misc/examples.running_locally.html>`_
-         you will also need to install S3 filesystem dependencies: ``pip install NREL-reV[s3]``
-
        - NOTE: If you install using conda and want to use `HSDS <https://github.com/NREL/hsds-examples>`_
          you will also need to install HSDS dependencies: ``pip install NREL-reV[hsds]``
 

--- a/examples/aws_pcluster/README.rst
+++ b/examples/aws_pcluster/README.rst
@@ -38,7 +38,7 @@ Setting up an AWS Parallel Cluster
     #. ``cd /shared/``
     #. ``git clone git@github.com:NREL/reV.git``
     #. ``cd /shared/reV/``
-    #. ``pip install -e .[s3]`` if you're using s3 filepaths or ``pip install -e .[hsds]`` if you're setting up an HSDS local server
+    #. ``pip install -e .[hsds]`` if you're setting up an HSDS local server
 
 #. Try running the reV ``aws_pcluster`` example:
 

--- a/examples/running_locally/README.rst
+++ b/examples/running_locally/README.rst
@@ -56,6 +56,14 @@ coordinates:
      [0.782 0.833 0.833 ... 0.833 0.833 0.833]
      [0.756 0.801 0.833 ... 0.833 0.833 0.833]]
 
+
+.. NOTE::
+    If you get an error saying the resource or SAM file doesn't exist, then you likely
+    installed from PyPi and did not get the test data bundled with your download. To
+    fix this, simply download the missing files from our
+    `online repository <https://github.com/NREL/reV/tree/main/tests/data>`_.
+
+
 pvwatts
 +++++++
 

--- a/examples/running_locally/README.rst
+++ b/examples/running_locally/README.rst
@@ -5,7 +5,9 @@ Run reV locally
 and `reV Econ <https://nrel.github.io/reV/_autosummary/reV.econ.econ.Econ.html#reV.econ.econ.Econ>`_
 can be run locally using resource .h5 files stored locally.
 
-For users outside of NREL: you can now point reV directly to filepaths on S3! This will stream small amounts of data from S3 directly to your computer without having to setup an IO server like HSDS. See the example for reading data directly from S3 `here <https://nrel.github.io/rex/misc/examples.fsspec.html>`_ and try the example below with resource file paths from S3. You will need to do an extra install ``pip install NREL-reV[s3]``.
+For users outside of NREL: you can now point reV directly to filepaths on S3! This will stream small amounts of data from S3 directly
+to your computer without having to setup an IO server like HSDS. See the example for reading data directly from S3
+`here <https://nrel.github.io/rex/misc/examples.fsspec.html>`_ and try the example below with resource file paths from S3.
 
 reV Gen
 -------


### PR DESCRIPTION
S3 package requirements are now always bundled with `rex`, and so we get them by default. No need for any extra installation, so I am removing references to that in our documentation (these break anyways, since we no longer have an `s3` feature in our `pyproject.toml`)