### PR TITLE
Add scalars for FOC and VOC cost inputs for SC agg

### DIFF
--- a/reV/bespoke/bespoke.py
+++ b/reV/bespoke/bespoke.py
@@ -1087,8 +1087,8 @@ class BespokeSinglePlant:
             fcr = lcoe_kwargs['fixed_charge_rate']
             cc = lcoe_kwargs['capital_cost']
             foc = lcoe_kwargs['fixed_operating_cost']
-            voc = lcoe_kwargs['variable_operating_cost']
-            aep = self.outputs['annual_energy-means']
+            voc = lcoe_kwargs['variable_operating_cost']  # $/kWh
+            aep = self.outputs['annual_energy-means']  # kWh
 
             my_mean_lcoe = lcoe_fcr(fcr, cc, foc, aep, voc)
 

--- a/reV/bespoke/bespoke.py
+++ b/reV/bespoke/bespoke.py
@@ -1406,14 +1406,13 @@ class BespokeSinglePlant:
             / reg_mult_foc
             / capacity_ac_mw
         )
-        self._meta[SupplyCurveField.COST_SITE_VOC_USD_PER_AC_MW] = (
-            self.plant_optimizer.variable_operating_cost
-            / capacity_ac_mw
+        self._meta[SupplyCurveField.COST_SITE_VOC_USD_PER_AC_MWH] = (
+            self.plant_optimizer.variable_operating_cost * 1000  # to $/MWh
         )
-        self._meta[SupplyCurveField.COST_BASE_VOC_USD_PER_AC_MW] = (
+        self._meta[SupplyCurveField.COST_BASE_VOC_USD_PER_AC_MWH] = (
             self.plant_optimizer.variable_operating_cost
             / reg_mult_voc
-            / capacity_ac_mw
+            * 1000  # to $/MWh
         )
         self._meta[SupplyCurveField.FIXED_CHARGE_RATE] = (
             self.plant_optimizer.fixed_charge_rate

--- a/reV/econ/economies_of_scale.py
+++ b/reV/econ/economies_of_scale.py
@@ -376,18 +376,16 @@ class EconomiesOfScale:
         Returns
         -------
         out : float | np.ndarray
-            Unscaled (raw) variable operating cost ($/MWh) from input
+            Unscaled (raw) variable operating cost ($/kWh) from input
             data arg
         """
-        voc_from_cap = self._data.get(
-            SupplyCurveField.COST_SITE_VOC_USD_PER_AC_MWH
-        )
-        if voc_from_cap is not None:
-            return voc_from_cap
+        voc_mwh = self._data.get(SupplyCurveField.COST_SITE_VOC_USD_PER_AC_MWH)
+        if voc_mwh is not None:
+            return voc_mwh / 1000  # convert to $/kWh
 
         key_list = ["variable_operating_cost", "mean_variable_operating_cost",
                     "voc", "mean_voc"]
-        return self._get_prioritized_keys(self._data, key_list) * 1000
+        return self._get_prioritized_keys(self._data, key_list)
 
     @property
     def scaled_variable_operating_cost(self):
@@ -397,7 +395,7 @@ class EconomiesOfScale:
         Returns
         -------
         out : float | np.ndarray
-            Variable operating cost ($/MWh) found in the data input arg
+            Variable operating cost ($/kWh) found in the data input arg
             scaled by the evaluated EconomiesOfScale equation.
         """
         voc = copy.deepcopy(self.raw_variable_operating_cost)
@@ -406,7 +404,7 @@ class EconomiesOfScale:
 
     @property
     def aep(self):
-        """Annual energy production back-calculated from the raw LCOE:
+        """Annual energy production (kWh) back-calculated from the raw LCOE:
 
         AEP = (fcr * raw_cap_cost + raw_foc) / (raw_lcoe - raw_voc)
 
@@ -415,12 +413,12 @@ class EconomiesOfScale:
         out : float | np.ndarray
         """
         num = self.fcr * self.raw_capital_cost + self.raw_fixed_operating_cost
-        denom = self.raw_lcoe - self.raw_variable_operating_cost
+        denom = self.raw_lcoe - (self.raw_variable_operating_cost * 1000)
         return num / denom * 1000  # convert MWh to KWh
 
     @property
     def raw_lcoe(self):
-        """Raw LCOE taken from the input data
+        """Raw LCOE ($/MWh) taken from the input data
 
         Returns
         -------
@@ -444,4 +442,4 @@ class EconomiesOfScale:
         """
         return lcoe_fcr(self.fcr, self.scaled_capital_cost,
                         self.scaled_fixed_operating_cost, self.aep,
-                        self.scaled_variable_operating_cost / 1000)
+                        self.scaled_variable_operating_cost)

--- a/reV/econ/economies_of_scale.py
+++ b/reV/econ/economies_of_scale.py
@@ -176,8 +176,7 @@ class EconomiesOfScale:
         Returns
         -------
         out : float | np.ndarray
-            Evaluated output of the EconomiesOfScale equation. Should be
-            numeric scalars to apply directly to the capital cost.
+            Evaluated output of the EconomiesOfScale equation.
         """
         if eqn is None:
             return 1
@@ -224,8 +223,8 @@ class EconomiesOfScale:
 
     @property
     def capital_cost_scalar(self):
-        """Evaluated output of the EconomiesOfScale equation. Should be
-        numeric scalars to apply directly to the capital cost.
+        """Evaluated output of the EconomiesOfScale capital cost equation.
+        Should be numeric scalars to apply directly to the capital cost.
 
         Returns
         -------
@@ -234,6 +233,34 @@ class EconomiesOfScale:
             numeric scalars to apply directly to the capital cost.
         """
         return self._evaluate(self._cap_eqn)
+
+    @property
+    def fixed_operating_cost_scalar(self):
+        """Evaluated output of the EconomiesOfScale fixed operating cost
+        equation. Should be numeric scalars to apply directly to the fixed
+        operating cost.
+
+        Returns
+        -------
+        out : float | np.ndarray
+            Evaluated output of the EconomiesOfScale equation. Should be
+            numeric scalars to apply directly to the fixed operating cost.
+        """
+        return self._evaluate(self._fixed_eqn)
+
+    @property
+    def variable_operating_cost_scalar(self):
+        """Evaluated output of the EconomiesOfScale equation variable
+        operating cost. Should be numeric scalars to apply directly to the
+        variable operating cost.
+
+        Returns
+        -------
+        out : float | np.ndarray
+            Evaluated output of the EconomiesOfScale equation. Should be
+            numeric scalars to apply directly to the variable operating cost.
+        """
+        return self._evaluate(self._var_eqn)
 
     def _cost_from_cap(self, col_name):
         """Get full cost value from cost per mw in data.

--- a/reV/econ/economies_of_scale.py
+++ b/reV/econ/economies_of_scale.py
@@ -429,7 +429,7 @@ class EconomiesOfScale:
 
     @property
     def scaled_lcoe(self):
-        """LCOE calculated with the scaled costs based on the
+        """LCOE ($/MWh) calculated with the scaled costs based on the
         EconomiesOfScale input equation.
 
         LCOE = (FCR * scaled_capital_cost + scaled_FOC) / AEP + scaled_VOC

--- a/reV/supply_curve/points.py
+++ b/reV/supply_curve/points.py
@@ -2421,19 +2421,46 @@ class GenerationSupplyCurvePoint(AggregationSupplyCurvePoint):
         return summary
 
     @staticmethod
-    def economies_of_scale(cap_cost_scale, summary):
+    def economies_of_scale(summary, cap_cost_scale=None, fixed_cost_scale=None,
+                           var_cost_scale=None):
         """Apply economies of scale to this point summary
 
         Parameters
         ----------
-        cap_cost_scale : str
-            LCOE scaling equation to implement "economies of scale".
-            Equation must be in python string format and return a scalar
-            value to multiply the capital cost by. Independent variables in
-            the equation should match the names of the columns in the reV
-            supply curve aggregation table.
         summary : dict
             Dictionary of summary outputs for this sc point.
+        cap_cost_scale : str, optional
+            Optional capital cost scaling equation to implement
+            "economies of scale". Equations must be in python string
+            format and must return a scalar value to multiply the
+            capital cost by. Independent variables in the equation
+            should match the names of the columns in the ``reV`` supply
+            curve aggregation output table (see the documentation of
+            :class:`~reV.supply_curve.sc_aggregation.SupplyCurveAggregation`
+            for details on available outputs). If ``None``, no economies
+            of scale are applied to the capital cost.
+        fixed_cost_scale : str, optional
+            Optional fixed operating cost scaling equation to implement
+            "economies of scale". Equations must be in python string
+            format and must return a scalar value to multiply the
+            fixed operating cost by. Independent variables in the
+            equation should match the names of the columns in the
+            ``reV`` supply curve aggregation output table (see the
+            documentation of
+            :class:`~reV.supply_curve.sc_aggregation.SupplyCurveAggregation`
+            for details on available outputs). If ``None``, no economies
+            of scale are applied to the fixed operating cost.
+        var_cost_scale : str, optional
+            Optional variable operating cost scaling equation to
+            implement "economies of scale". Equations must be in python
+            string format and must return a scalar value to multiply the
+            variable operating cost by. Independent variables in the
+            equation should match the names of the columns in the
+            ``reV`` supply curve aggregation output table (see the
+            documentation of
+            :class:`~reV.supply_curve.sc_aggregation.SupplyCurveAggregation`
+            for details on available outputs). If ``None``, no economies
+            of scale are applied to the variable operating cost.
 
         Returns
         -------
@@ -2441,15 +2468,35 @@ class GenerationSupplyCurvePoint(AggregationSupplyCurvePoint):
             Dictionary of summary outputs for this sc point.
         """
 
-        eos = EconomiesOfScale(cap_cost_scale, summary)
+        eos = EconomiesOfScale(data=summary, cap_eqn=cap_cost_scale,
+                               fixed_eqn=fixed_cost_scale,
+                               var_eqn=var_cost_scale)
         summary[SupplyCurveField.RAW_LCOE] = eos.raw_lcoe
         summary[SupplyCurveField.MEAN_LCOE] = eos.scaled_lcoe
         summary[SupplyCurveField.EOS_MULT] = eos.capital_cost_scalar
+        summary[SupplyCurveField.FIXED_EOS_MULT] = (
+            eos.fixed_operating_cost_scalar)
+        summary[SupplyCurveField.VAR_EOS_MULT] = (
+            eos.variable_operating_cost_scalar)
+
         cost = summary[SupplyCurveField.COST_SITE_OCC_USD_PER_AC_MW]
         if cost is not None:
             summary[SupplyCurveField.COST_SITE_OCC_USD_PER_AC_MW] = (
                 cost * summary[SupplyCurveField.EOS_MULT]
             )
+
+        cost = summary[SupplyCurveField.COST_SITE_FOC_USD_PER_AC_MW]
+        if cost is not None:
+            summary[SupplyCurveField.COST_SITE_FOC_USD_PER_AC_MW] = (
+                cost * summary[SupplyCurveField.FIXED_EOS_MULT]
+            )
+
+        cost = summary[SupplyCurveField.COST_SITE_VOC_USD_PER_AC_MWH]
+        if cost is not None:
+            summary[SupplyCurveField.COST_SITE_VOC_USD_PER_AC_MWH] = (
+                cost * summary[SupplyCurveField.VAR_EOS_MULT]
+            )
+
         return summary
 
     @classmethod
@@ -2476,6 +2523,8 @@ class GenerationSupplyCurvePoint(AggregationSupplyCurvePoint):
         args=None,
         data_layers=None,
         cap_cost_scale=None,
+        fixed_cost_scale=None,
+        var_cost_scale=None,
         recalc_lcoe=True,
         zone_mask=None,
     ):
@@ -2547,12 +2596,41 @@ class GenerationSupplyCurvePoint(AggregationSupplyCurvePoint):
             Aggregation data layers. Must be a dictionary keyed by data label
             name. Each value must be another dictionary with "dset", "method",
             and "fpath", by default None
-        cap_cost_scale : str | None
-            Optional LCOE scaling equation to implement "economies of scale".
-            Equations must be in python string format and return a scalar
-            value to multiply the capital cost by. Independent variables in
-            the equation should match the names of the columns in the reV
-            supply curve aggregation table.
+        cap_cost_scale : str, optional
+            Optional capital cost scaling equation to implement
+            "economies of scale". Equations must be in python string
+            format and must return a scalar value to multiply the
+            capital cost by. Independent variables in the equation
+            should match the names of the columns in the ``reV`` supply
+            curve aggregation output table (see the documentation of
+            :class:`~reV.supply_curve.sc_aggregation.SupplyCurveAggregation`
+            for details on available outputs). If ``None``, no economies
+            of scale are applied to the capital cost.
+            By default, ``None``.
+        fixed_cost_scale : str, optional
+            Optional fixed operating cost scaling equation to implement
+            "economies of scale". Equations must be in python string
+            format and must return a scalar value to multiply the
+            fixed operating cost by. Independent variables in the
+            equation should match the names of the columns in the
+            ``reV`` supply curve aggregation output table (see the
+            documentation of
+            :class:`~reV.supply_curve.sc_aggregation.SupplyCurveAggregation`
+            for details on available outputs). If ``None``, no economies
+            of scale are applied to the fixed operating cost.
+            By default, ``None``.
+        var_cost_scale : str, optional
+            Optional variable operating cost scaling equation to
+            implement "economies of scale". Equations must be in python
+            string format and must return a scalar value to multiply the
+            variable operating cost by. Independent variables in the
+            equation should match the names of the columns in the
+            ``reV`` supply curve aggregation output table (see the
+            documentation of
+            :class:`~reV.supply_curve.sc_aggregation.SupplyCurveAggregation`
+            for details on available outputs). If ``None``, no economies
+            of scale are applied to the variable operating cost.
+            By default, ``None``.
         recalc_lcoe : bool
             Flag to re-calculate the LCOE from the multi-year mean capacity
             factor and annual energy production data. This requires several
@@ -2596,8 +2674,10 @@ class GenerationSupplyCurvePoint(AggregationSupplyCurvePoint):
             if data_layers is not None:
                 summary = point.agg_data_layers(summary, data_layers)
 
-            if cap_cost_scale is not None:
-                summary = point.economies_of_scale(cap_cost_scale, summary)
+            if any((cap_cost_scale, fixed_cost_scale, var_cost_scale)):
+                summary = point.economies_of_scale(summary, cap_cost_scale,
+                                                   fixed_cost_scale,
+                                                   var_cost_scale)
 
         for arg, val in summary.items():
             if val is None:

--- a/reV/supply_curve/points.py
+++ b/reV/supply_curve/points.py
@@ -2249,6 +2249,13 @@ class GenerationSupplyCurvePoint(AggregationSupplyCurvePoint):
                   else self.capacity_ac)
         return sc_point_cost / ac_cap
 
+    def _compute_voc_per_ac_mwh(self, dset):
+        """Compute variable operating cost per MWh """
+        if dset not in self.gen.datasets:
+            return None
+
+        return self.exclusion_weighted_mean(self.gen[dset]) * 1000  # to $/MWh
+
     @property
     def mean_h5_dsets_data(self):
         """Get the mean supplemental h5 datasets data (optional)
@@ -2380,11 +2387,11 @@ class GenerationSupplyCurvePoint(AggregationSupplyCurvePoint):
             SupplyCurveField.COST_BASE_FOC_USD_PER_AC_MW: (
                 self._compute_cost_per_ac_mw("base_fixed_operating_cost")
             ),
-            SupplyCurveField.COST_SITE_VOC_USD_PER_AC_MW: (
-                self._compute_cost_per_ac_mw("variable_operating_cost")
+            SupplyCurveField.COST_SITE_VOC_USD_PER_AC_MWH: (
+                self._compute_voc_per_ac_mwh("variable_operating_cost")
             ),
-            SupplyCurveField.COST_BASE_VOC_USD_PER_AC_MW: (
-                self._compute_cost_per_ac_mw("base_variable_operating_cost")
+            SupplyCurveField.COST_BASE_VOC_USD_PER_AC_MWH: (
+                self._compute_voc_per_ac_mwh("base_variable_operating_cost")
             ),
             SupplyCurveField.FIXED_CHARGE_RATE: self.fixed_charge_rate,
         }

--- a/reV/supply_curve/sc_aggregation.py
+++ b/reV/supply_curve/sc_aggregation.py
@@ -252,7 +252,8 @@ class SupplyCurveAggregation(BaseAggregation):
                  res_class_bins=None, cf_dset='cf_mean-means',
                  lcoe_dset='lcoe_fcr-means', h5_dsets=None, data_layers=None,
                  power_density=None, friction_fpath=None, friction_dset=None,
-                 cap_cost_scale=None, recalc_lcoe=True, zones_dset=None):
+                 cap_cost_scale=None, fixed_cost_scale=None,
+                 var_cost_scale=None, recalc_lcoe=True, zones_dset=None):
         r"""ReV supply curve points aggregation framework.
 
         ``reV`` supply curve aggregation combines a high-resolution
@@ -518,15 +519,40 @@ class SupplyCurveAggregation(BaseAggregation):
             ``None``, no friction data is aggregated.
             By default, ``None``.
         cap_cost_scale : str, optional
-            Optional LCOE scaling equation to implement "economies of
-            scale". Equations must be in python string format and must
-            return a scalar value to multiply the capital cost by.
-            Independent variables in the equation should match the names
-            of the columns in the ``reV`` supply curve aggregation
-            output table (see the documentation of
+            Optional capital cost scaling equation to implement
+            "economies of scale". Equations must be in python string
+            format and must return a scalar value to multiply the
+            capital cost by. Independent variables in the equation
+            should match the names of the columns in the ``reV`` supply
+            curve aggregation output table (see the documentation of
             :class:`~reV.supply_curve.sc_aggregation.SupplyCurveAggregation`
             for details on available outputs). If ``None``, no economies
-            of scale are applied. By default, ``None``.
+            of scale are applied to the capital cost.
+            By default, ``None``.
+        fixed_cost_scale : str, optional
+            Optional fixed operating cost scaling equation to implement
+            "economies of scale". Equations must be in python string
+            format and must return a scalar value to multiply the
+            fixed operating cost by. Independent variables in the
+            equation should match the names of the columns in the
+            ``reV`` supply curve aggregation output table (see the
+            documentation of
+            :class:`~reV.supply_curve.sc_aggregation.SupplyCurveAggregation`
+            for details on available outputs). If ``None``, no economies
+            of scale are applied to the fixed operating cost.
+            By default, ``None``.
+        var_cost_scale : str, optional
+            Optional variable operating cost scaling equation to
+            implement "economies of scale". Equations must be in python
+            string format and must return a scalar value to multiply the
+            variable operating cost by. Independent variables in the
+            equation should match the names of the columns in the
+            ``reV`` supply curve aggregation output table (see the
+            documentation of
+            :class:`~reV.supply_curve.sc_aggregation.SupplyCurveAggregation`
+            for details on available outputs). If ``None``, no economies
+            of scale are applied to the variable operating cost.
+            By default, ``None``.
         recalc_lcoe : bool, optional
             Flag to re-calculate the LCOE from the multi-year mean
             capacity factor and annual energy production data. This
@@ -711,6 +737,8 @@ class SupplyCurveAggregation(BaseAggregation):
         self._lcoe_dset = lcoe_dset
         self._h5_dsets = h5_dsets
         self._cap_cost_scale = cap_cost_scale
+        self._fixed_cost_scale = fixed_cost_scale
+        self._var_cost_scale = var_cost_scale
         self._power_density = power_density
         self._friction_fpath = friction_fpath
         self._friction_dset = friction_dset
@@ -958,6 +986,8 @@ class SupplyCurveAggregation(BaseAggregation):
         friction_dset=None,
         excl_area=None,
         cap_cost_scale=None,
+        fixed_cost_scale=None,
+        var_cost_scale=None,
         recalc_lcoe=True,
         zones_dset=None,
     ):
@@ -1041,12 +1071,41 @@ class SupplyCurveAggregation(BaseAggregation):
         excl_area : float | None, optional
             Area of an exclusion pixel in km2. None will try to infer the area
             from the profile transform attribute in excl_fpath, by default None
-        cap_cost_scale : str | None
-            Optional LCOE scaling equation to implement "economies of scale".
-            Equations must be in python string format and return a scalar
-            value to multiply the capital cost by. Independent variables in
-            the equation should match the names of the columns in the reV
-            supply curve aggregation table.
+        cap_cost_scale : str, optional
+            Optional capital cost scaling equation to implement
+            "economies of scale". Equations must be in python string
+            format and must return a scalar value to multiply the
+            capital cost by. Independent variables in the equation
+            should match the names of the columns in the ``reV`` supply
+            curve aggregation output table (see the documentation of
+            :class:`~reV.supply_curve.sc_aggregation.SupplyCurveAggregation`
+            for details on available outputs). If ``None``, no economies
+            of scale are applied to the capital cost.
+            By default, ``None``.
+        fixed_cost_scale : str, optional
+            Optional fixed operating cost scaling equation to implement
+            "economies of scale". Equations must be in python string
+            format and must return a scalar value to multiply the
+            fixed operating cost by. Independent variables in the
+            equation should match the names of the columns in the
+            ``reV`` supply curve aggregation output table (see the
+            documentation of
+            :class:`~reV.supply_curve.sc_aggregation.SupplyCurveAggregation`
+            for details on available outputs). If ``None``, no economies
+            of scale are applied to the fixed operating cost.
+            By default, ``None``.
+        var_cost_scale : str, optional
+            Optional variable operating cost scaling equation to
+            implement "economies of scale". Equations must be in python
+            string format and must return a scalar value to multiply the
+            variable operating cost by. Independent variables in the
+            equation should match the names of the columns in the
+            ``reV`` supply curve aggregation output table (see the
+            documentation of
+            :class:`~reV.supply_curve.sc_aggregation.SupplyCurveAggregation`
+            for details on available outputs). If ``None``, no economies
+            of scale are applied to the variable operating cost.
+            By default, ``None``.
         recalc_lcoe : bool
             Flag to re-calculate the LCOE from the multi-year mean capacity
             factor and annual energy production data. This requires several
@@ -1143,6 +1202,8 @@ class SupplyCurveAggregation(BaseAggregation):
                                 close=False,
                                 friction_layer=fh.friction_layer,
                                 cap_cost_scale=cap_cost_scale,
+                                fixed_cost_scale=fixed_cost_scale,
+                                var_cost_scale=var_cost_scale,
                                 recalc_lcoe=recalc_lcoe,
                                 zone_mask=zone_mask,
                             )
@@ -1262,6 +1323,8 @@ class SupplyCurveAggregation(BaseAggregation):
                         args=args,
                         excl_area=self._excl_area,
                         cap_cost_scale=self._cap_cost_scale,
+                        fixed_cost_scale=self._fixed_cost_scale,
+                        var_cost_scale=self._var_cost_scale,
                         recalc_lcoe=self._recalc_lcoe,
                         zones_dset=self._zones_dset,
                     )
@@ -1401,6 +1464,8 @@ class SupplyCurveAggregation(BaseAggregation):
                 args=args,
                 excl_area=self._excl_area,
                 cap_cost_scale=self._cap_cost_scale,
+                fixed_cost_scale=self._fixed_cost_scale,
+                var_cost_scale=self._var_cost_scale,
                 recalc_lcoe=self._recalc_lcoe,
                 zones_dset=self._zones_dset,
             )

--- a/reV/utilities/__init__.py
+++ b/reV/utilities/__init__.py
@@ -155,8 +155,8 @@ class SupplyCurveField(FieldEnum):
     COST_SITE_OCC_USD_PER_AC_MW = "cost_site_occ_usd_per_ac_mw"
     COST_BASE_FOC_USD_PER_AC_MW = "cost_base_foc_usd_per_ac_mw"
     COST_SITE_FOC_USD_PER_AC_MW = "cost_site_foc_usd_per_ac_mw"
-    COST_BASE_VOC_USD_PER_AC_MW = "cost_base_voc_usd_per_ac_mw"
-    COST_SITE_VOC_USD_PER_AC_MW = "cost_site_voc_usd_per_ac_mw"
+    COST_BASE_VOC_USD_PER_AC_MWH = "cost_base_voc_usd_per_ac_mwh"
+    COST_SITE_VOC_USD_PER_AC_MWH = "cost_site_voc_usd_per_ac_mwh"
     FIXED_CHARGE_RATE = "fixed_charge_rate"
 
     # Bespoke outputs

--- a/reV/utilities/__init__.py
+++ b/reV/utilities/__init__.py
@@ -149,6 +149,8 @@ class SupplyCurveField(FieldEnum):
     MEAN_LCOE_FRICTION = "lcoe_friction_usd_per_mwh"
     RAW_LCOE = "lcoe_raw_usd_per_mwh"
     EOS_MULT = "multiplier_cc_eos"
+    FIXED_EOS_MULT = "multiplier_foc_eos"
+    VAR_EOS_MULT = "multiplier_voc_eos"
     REG_MULT = "multiplier_cc_regional"
     SC_POINT_ANNUAL_ENERGY_MWH = "annual_energy_site_mwh"
     COST_BASE_OCC_USD_PER_AC_MW = "cost_base_occ_usd_per_ac_mw"

--- a/tests/test_bespoke.py
+++ b/tests/test_bespoke.py
@@ -105,8 +105,8 @@ EXPECTED_META_COLUMNS = ["gid",  # needed for H5 collection to work properly
                          SupplyCurveField.COST_SITE_OCC_USD_PER_AC_MW,
                          SupplyCurveField.COST_BASE_FOC_USD_PER_AC_MW,
                          SupplyCurveField.COST_SITE_FOC_USD_PER_AC_MW,
-                         SupplyCurveField.COST_BASE_VOC_USD_PER_AC_MW,
-                         SupplyCurveField.COST_SITE_VOC_USD_PER_AC_MW,
+                         SupplyCurveField.COST_BASE_VOC_USD_PER_AC_MWH,
+                         SupplyCurveField.COST_SITE_VOC_USD_PER_AC_MWH,
                          SupplyCurveField.FIXED_CHARGE_RATE,
                          SupplyCurveField.INCLUDED_AREA,
                          SupplyCurveField.INCLUDED_AREA_CAPACITY_DENSITY,
@@ -684,16 +684,15 @@ def test_bespoke():
             meta[SupplyCurveField.COST_SITE_FOC_USD_PER_AC_MW],
             meta[SupplyCurveField.COST_BASE_FOC_USD_PER_AC_MW])
         assert not np.allclose(
-            meta[SupplyCurveField.COST_SITE_VOC_USD_PER_AC_MW],
-            meta[SupplyCurveField.COST_BASE_VOC_USD_PER_AC_MW])
+            meta[SupplyCurveField.COST_SITE_VOC_USD_PER_AC_MWH],
+            meta[SupplyCurveField.COST_BASE_VOC_USD_PER_AC_MWH])
 
         fcr = meta[SupplyCurveField.FIXED_CHARGE_RATE]
         cap_cost = (meta[SupplyCurveField.COST_SITE_OCC_USD_PER_AC_MW]
                     * meta[SupplyCurveField.CAPACITY_AC_MW])
         foc = (meta[SupplyCurveField.COST_SITE_FOC_USD_PER_AC_MW]
                * meta[SupplyCurveField.CAPACITY_AC_MW])
-        voc = (meta[SupplyCurveField.COST_SITE_VOC_USD_PER_AC_MW]
-               * meta[SupplyCurveField.CAPACITY_AC_MW])
+        voc = meta[SupplyCurveField.COST_SITE_VOC_USD_PER_AC_MWH]
         aep = meta[SupplyCurveField.SC_POINT_ANNUAL_ENERGY_MWH]
         lcoe_site = lcoe_fcr(fcr, cap_cost, foc, aep, voc)
 
@@ -704,8 +703,7 @@ def test_bespoke():
         foc = (meta[SupplyCurveField.COST_BASE_FOC_USD_PER_AC_MW]
                * meta[SupplyCurveField.CAPACITY_AC_MW]
                * np.array([3, 4]))
-        voc = (meta[SupplyCurveField.COST_BASE_VOC_USD_PER_AC_MW]
-               * meta[SupplyCurveField.CAPACITY_AC_MW]
+        voc = (meta[SupplyCurveField.COST_BASE_VOC_USD_PER_AC_MWH]
                * np.array([5, 6]))
         lcoe_base = lcoe_fcr(fcr, cap_cost, foc, aep, voc)
 
@@ -1293,8 +1291,8 @@ def test_bespoke_prior_run():
             SupplyCurveField.COST_SITE_OCC_USD_PER_AC_MW,
             SupplyCurveField.COST_BASE_FOC_USD_PER_AC_MW,
             SupplyCurveField.COST_SITE_FOC_USD_PER_AC_MW,
-            SupplyCurveField.COST_BASE_VOC_USD_PER_AC_MW,
-            SupplyCurveField.COST_SITE_VOC_USD_PER_AC_MW,
+            SupplyCurveField.COST_BASE_VOC_USD_PER_AC_MWH,
+            SupplyCurveField.COST_SITE_VOC_USD_PER_AC_MWH,
             SupplyCurveField.FIXED_CHARGE_RATE,
             SupplyCurveField.BESPOKE_AEP,
             SupplyCurveField.BESPOKE_OBJECTIVE,

--- a/tests/test_econ_of_scale.py
+++ b/tests/test_econ_of_scale.py
@@ -147,7 +147,6 @@ def test_econ_of_scale_baseline(request_h5):
         h5_dsets = ["capital_cost", "fixed_operating_cost",
                     "fixed_charge_rate", "variable_operating_cost"]
 
-
     with tempfile.TemporaryDirectory() as td:
         gen_temp = os.path.join(td, "ri_my_pv_gen.h5")
         shutil.copy(GEN, gen_temp)

--- a/tests/test_econ_of_scale.py
+++ b/tests/test_econ_of_scale.py
@@ -75,52 +75,56 @@ def test_pass_through_lcoe_args():
     assert "cf_mean" in gen.out
 
 
-def test_lcoe_calc_simple():
+@pytest.mark.parametrize("cap_eqn", [None, 1, 2, '1 / some_sc_output'])
+@pytest.mark.parametrize("fixed_eqn", [None, 1, 2, '1 / some_sc_output'])
+@pytest.mark.parametrize("var_eqn", [None, 1, 2, '1 / some_sc_output'])
+def test_lcoe_calc_simple(cap_eqn, fixed_eqn, var_eqn):
     """Test the EconomiesOfScale LCOE calculator without cap cost scalar"""
-    eqn = None
     # from pvwattsv7 defaults
     data = {
-        "aep": 35188456.00,
-        "capital_cost": 53455000.00,
-        "foc": 360000.00,
-        "voc": 0,
+        "aep": 35188456.00,  # kW
+        "capital_cost": 53455000.00,  # $
+        "foc": 360000.00,  # $
+        "voc": 0.006,  # $/kWh
         "fcr": 0.096,
+        "some_sc_output": 2,
     }
 
-    true_lcoe = (data["fcr"] * data["capital_cost"]
-                 + data["foc"]) / (data["aep"] / 1000)
+    if cap_eqn is None:
+        cap_scalar = 1
+    elif cap_eqn == '1 / some_sc_output':
+        cap_scalar = 0.5
+    else:
+        cap_scalar = cap_eqn
+
+    if fixed_eqn is None:
+        fixed_scalar = 1
+    elif fixed_eqn == '1 / some_sc_output':
+        fixed_scalar = 0.5
+    else:
+        fixed_scalar = fixed_eqn
+
+    if var_eqn is None:
+        var_scalar = 1
+    elif var_eqn == '1 / some_sc_output':
+        var_scalar = 0.5
+    else:
+        var_scalar = var_eqn
+
+    true_lcoe = ((data["fcr"]
+                 * data["capital_cost"]
+                 + data["foc"])
+                 / (data["aep"] / 1000)) + data["voc"] * 1000
+    true_scaled = ((data['fcr']
+                    * data["capital_cost"] * cap_scalar
+                    + data['foc'] * fixed_scalar)
+                   / (data['aep'] / 1000)) + data["voc"] * var_scalar * 1000
+
     data[SupplyCurveField.MEAN_LCOE] = true_lcoe
 
-    eos = EconomiesOfScale(eqn, data)
-    assert eos.raw_capital_cost == eos.scaled_capital_cost
-    assert eos.raw_capital_cost == data["capital_cost"]
-    assert np.allclose(eos.raw_lcoe, true_lcoe, rtol=0.001)
-    assert np.allclose(eos.scaled_lcoe, true_lcoe, rtol=0.001)
-
-    eqn = 1
-    eos = EconomiesOfScale(eqn, data)
-    assert eos.raw_capital_cost == eos.scaled_capital_cost
-    assert eos.raw_capital_cost == data["capital_cost"]
-    assert np.allclose(eos.raw_lcoe, true_lcoe, rtol=0.001)
-    assert np.allclose(eos.scaled_lcoe, true_lcoe, rtol=0.001)
-
-    eqn = 2
-    true_scaled = ((data['fcr'] * eqn * data["capital_cost"]
-                    + data['foc'])
-                   / (data['aep'] / 1000))
-    eos = EconomiesOfScale(eqn, data)
-    assert eqn * eos.raw_capital_cost == eos.scaled_capital_cost
-    assert eos.raw_capital_cost == data["capital_cost"]
-    assert np.allclose(eos.raw_lcoe, true_lcoe, rtol=0.001)
-    assert np.allclose(eos.scaled_lcoe, true_scaled, rtol=0.001)
-
-    data['system_capacity'] = 2
-    eqn = '1 / system_capacity'
-    true_scaled = ((data['fcr'] * 0.5 * data["capital_cost"]
-                    + data['foc'])
-                   / (data['aep'] / 1000))
-    eos = EconomiesOfScale(eqn, data)
-    assert 0.5 * eos.raw_capital_cost == eos.scaled_capital_cost
+    eos = EconomiesOfScale(data, cap_eqn=cap_eqn, fixed_eqn=fixed_eqn,
+                           var_eqn=var_eqn)
+    assert cap_scalar * eos.raw_capital_cost == eos.scaled_capital_cost
     assert eos.raw_capital_cost == data["capital_cost"]
     assert np.allclose(eos.raw_lcoe, true_lcoe, rtol=0.001)
     assert np.allclose(eos.scaled_lcoe, true_scaled, rtol=0.001)
@@ -136,7 +140,7 @@ def test_econ_of_scale_baseline(request_h5):
         "fixed_operating_cost": 260000,
         "fixed_charge_rate": 0.096,
         "system_capacity": 20000,
-        "variable_operating_cost": 0,
+        "variable_operating_cost": 0.4,
     }
     h5_dsets = None
     if request_h5:
@@ -156,7 +160,8 @@ def test_econ_of_scale_baseline(request_h5):
         lcoe = (1000
                 * (data['fixed_charge_rate'] * data['capital_cost']
                    + data['fixed_operating_cost'])
-                / (cf * data['system_capacity'] * 8760))
+                / (cf * data['system_capacity'] * 8760)
+                + data['variable_operating_cost'])
 
         with h5py.File(gen_temp, "a") as res:
             res["lcoe_fcr-means"][...] = lcoe
@@ -210,13 +215,14 @@ def test_econ_of_scale_baseline(request_h5):
                            sc_df[SupplyCurveField.COST_SITE_OCC_USD_PER_AC_MW])
 
 
-def test_sc_agg_econ_scale():
+@pytest.mark.parametrize("voc", [0, 0.1])
+def test_sc_agg_econ_scale(voc):
     """Test supply curve agg with LCOE scaling based on plant capacity."""
     data = {
         "capital_cost": 53455000,
         "fixed_operating_cost": 360000,
         "fixed_charge_rate": 0.096,
-        "variable_operating_cost": 0,
+        "variable_operating_cost": voc,
     }
 
     with tempfile.TemporaryDirectory() as td:
@@ -283,11 +289,12 @@ def test_sc_agg_econ_scale():
 
         aep = ((sc_df['mean_fixed_charge_rate'] * sc_df['mean_capital_cost']
                 + sc_df['mean_fixed_operating_cost'])
-               / sc_df[SupplyCurveField.RAW_LCOE])
+               / (sc_df[SupplyCurveField.RAW_LCOE]
+                  - data['variable_operating_cost'] * 1000))
 
         true_raw_lcoe = ((data['fixed_charge_rate'] * data['capital_cost']
                           + data['fixed_operating_cost'])
-                         / aep + data['variable_operating_cost'])
+                         / aep + data['variable_operating_cost'] * 1000)
 
         eval_inputs = {k: sc_df[k].values.flatten() for k in sc_df.columns}
         # pylint: disable=eval-used
@@ -296,14 +303,15 @@ def test_sc_agg_econ_scale():
         true_scaled_lcoe = (
             data["fixed_charge_rate"] * scalars * data["capital_cost"]
             + data["fixed_operating_cost"]
-        ) / aep + data["variable_operating_cost"]
+        ) / aep + data["variable_operating_cost"] * 1000
 
         assert np.allclose(scalars, sc_df[SupplyCurveField.EOS_MULT])
 
         assert np.allclose(true_scaled_lcoe, sc_df[SupplyCurveField.MEAN_LCOE])
         assert np.allclose(true_raw_lcoe, sc_df[SupplyCurveField.RAW_LCOE])
         sc_df = sc_df.sort_values(SupplyCurveField.CAPACITY_AC_MW)
-        assert all(sc_df[SupplyCurveField.MEAN_LCOE].diff()[1:] < 0)
+        if voc == 0:
+            assert all(sc_df[SupplyCurveField.MEAN_LCOE].diff()[1:] < 0)
         for i in sc_df.index.values:
             if sc_df.loc[i, 'scalars'] < 1:
                 assert (sc_df.loc[i, SupplyCurveField.MEAN_LCOE]

--- a/tests/test_supply_curve_sc_aggregation.py
+++ b/tests/test_supply_curve_sc_aggregation.py
@@ -481,14 +481,15 @@ def test_data_layer_methods():
     "cap_cost_scale",
     ["1", f"2 * np.multiply(1000, {SupplyCurveField.CAPACITY_AC_MW}) ** -0.3"]
 )
-def test_recalc_lcoe(cap_cost_scale):
+@pytest.mark.parametrize("voc", [0, 0.1])
+def test_recalc_lcoe(cap_cost_scale, voc):
     """Test supply curve aggregation with the re-calculation of lcoe using the
     multi-year mean capacity factor"""
 
     data = {"capital_cost": 34900000,
             "fixed_operating_cost": 280000,
             "fixed_charge_rate": 0.09606382995843887,
-            "variable_operating_cost": 0,
+            "variable_operating_cost": voc,
             'system_capacity': 20000}
     annual_cf = [0.24, 0.26, 0.37, 0.15]
     annual_lcoe = []
@@ -617,7 +618,7 @@ def test_recalc_lcoe(cap_cost_scale):
                 * summary[SupplyCurveField.EOS_MULT])
     foc = (summary[SupplyCurveField.COST_BASE_FOC_USD_PER_AC_MW]
            * summary[SupplyCurveField.CAPACITY_AC_MW])
-    voc = summary[SupplyCurveField.COST_BASE_VOC_USD_PER_AC_MWH]
+    voc = summary[SupplyCurveField.COST_BASE_VOC_USD_PER_AC_MWH] / 1000
 
     lcoe = lcoe_fcr(fcr, cap_cost, foc, aep_kwh, voc)
     assert np.allclose(lcoe, summary[SupplyCurveField.MEAN_LCOE])

--- a/tests/test_supply_curve_sc_aggregation.py
+++ b/tests/test_supply_curve_sc_aggregation.py
@@ -605,8 +605,7 @@ def test_recalc_lcoe(cap_cost_scale):
                 * summary[SupplyCurveField.CAPACITY_AC_MW])
     foc = (summary[SupplyCurveField.COST_SITE_FOC_USD_PER_AC_MW]
            * summary[SupplyCurveField.CAPACITY_AC_MW])
-    voc = (summary[SupplyCurveField.COST_SITE_VOC_USD_PER_AC_MW]
-           * summary[SupplyCurveField.CAPACITY_AC_MW])
+    voc = summary[SupplyCurveField.COST_SITE_VOC_USD_PER_AC_MWH] / 1000
     aep_kwh = summary[SupplyCurveField.SC_POINT_ANNUAL_ENERGY_MWH] * 1000
 
     lcoe = lcoe_fcr(fcr, cap_cost, foc, aep_kwh, voc)
@@ -618,8 +617,7 @@ def test_recalc_lcoe(cap_cost_scale):
                 * summary[SupplyCurveField.EOS_MULT])
     foc = (summary[SupplyCurveField.COST_BASE_FOC_USD_PER_AC_MW]
            * summary[SupplyCurveField.CAPACITY_AC_MW])
-    voc = (summary[SupplyCurveField.COST_BASE_VOC_USD_PER_AC_MW]
-           * summary[SupplyCurveField.CAPACITY_AC_MW])
+    voc = summary[SupplyCurveField.COST_BASE_VOC_USD_PER_AC_MWH]
 
     lcoe = lcoe_fcr(fcr, cap_cost, foc, aep_kwh, voc)
     assert np.allclose(lcoe, summary[SupplyCurveField.MEAN_LCOE])


### PR DESCRIPTION
Add ability to specify EOS equations for FOC and VOC when running supply curve aggregation. 

Also fix handling of VOC (no scaling by capacity) and renames VOC column for correct units (both are breaking changes).