### PR TITLE
Rename SC output column

### DIFF
--- a/reV/bespoke/bespoke.py
+++ b/reV/bespoke/bespoke.py
@@ -1387,12 +1387,12 @@ class BespokeSinglePlant:
         self._meta[SupplyCurveField.EOS_MULT] = eos_mult
         self._meta[SupplyCurveField.REG_MULT] = reg_mult_cc
 
-        self._meta[SupplyCurveField.COST_SITE_OCC_USD_PER_AC_MW] = (
+        self._meta[SupplyCurveField.COST_SITE_CC_USD_PER_AC_MW] = (
             (self.plant_optimizer.capital_cost
              + self.plant_optimizer.balance_of_system_cost)
             / capacity_ac_mw
         )
-        self._meta[SupplyCurveField.COST_BASE_OCC_USD_PER_AC_MW] = (
+        self._meta[SupplyCurveField.COST_BASE_CC_USD_PER_AC_MW] = (
             (self.plant_optimizer.capital_cost / eos_mult / reg_mult_cc
              + self.plant_optimizer.balance_of_system_cost / reg_mult_bos)
             / capacity_ac_mw

--- a/reV/econ/economies_of_scale.py
+++ b/reV/econ/economies_of_scale.py
@@ -224,7 +224,7 @@ class EconomiesOfScale:
             Unscaled (raw) capital_cost found in the data input arg.
         """
         raw_capital_cost_from_cap = self._cost_from_cap(
-            SupplyCurveField.COST_SITE_OCC_USD_PER_AC_MW
+            SupplyCurveField.COST_SITE__USD_PER_AC_MW
         )
         if raw_capital_cost_from_cap is not None:
             return raw_capital_cost_from_cap

--- a/reV/econ/economies_of_scale.py
+++ b/reV/econ/economies_of_scale.py
@@ -295,7 +295,7 @@ class EconomiesOfScale:
             Unscaled (raw) capital_cost ($) found in the data input arg.
         """
         raw_capital_cost_from_cap = self._cost_from_cap(
-            SupplyCurveField.COST_SITE__USD_PER_AC_MW
+            SupplyCurveField.COST_SITE_CC_USD_PER_AC_MW
         )
         if raw_capital_cost_from_cap is not None:
             return raw_capital_cost_from_cap

--- a/reV/supply_curve/points.py
+++ b/reV/supply_curve/points.py
@@ -2368,10 +2368,10 @@ class GenerationSupplyCurvePoint(AggregationSupplyCurvePoint):
             SupplyCurveField.SC_POINT_ANNUAL_ENERGY_MWH: (
                 self.sc_point_annual_energy
             ),
-            SupplyCurveField.COST_SITE_OCC_USD_PER_AC_MW: (
+            SupplyCurveField.COST_SITE_CC_USD_PER_AC_MW: (
                 self._compute_cost_per_ac_mw("capital_cost")
             ),
-            SupplyCurveField.COST_BASE_OCC_USD_PER_AC_MW: (
+            SupplyCurveField.COST_BASE_CC_USD_PER_AC_MW: (
                 self._compute_cost_per_ac_mw("base_capital_cost")
             ),
             SupplyCurveField.COST_SITE_FOC_USD_PER_AC_MW: (
@@ -2438,9 +2438,9 @@ class GenerationSupplyCurvePoint(AggregationSupplyCurvePoint):
         summary[SupplyCurveField.RAW_LCOE] = eos.raw_lcoe
         summary[SupplyCurveField.MEAN_LCOE] = eos.scaled_lcoe
         summary[SupplyCurveField.EOS_MULT] = eos.capital_cost_scalar
-        cost = summary[SupplyCurveField.COST_SITE_OCC_USD_PER_AC_MW]
+        cost = summary[SupplyCurveField.COST_SITE_CC_USD_PER_AC_MW]
         if cost is not None:
-            summary[SupplyCurveField.COST_SITE_OCC_USD_PER_AC_MW] = (
+            summary[SupplyCurveField.COST_SITE_CC_USD_PER_AC_MW] = (
                 cost * summary[SupplyCurveField.EOS_MULT]
             )
         return summary

--- a/reV/utilities/__init__.py
+++ b/reV/utilities/__init__.py
@@ -151,8 +151,8 @@ class SupplyCurveField(FieldEnum):
     EOS_MULT = "multiplier_cc_eos"
     REG_MULT = "multiplier_cc_regional"
     SC_POINT_ANNUAL_ENERGY_MWH = "annual_energy_site_mwh"
-    COST_BASE_OCC_USD_PER_AC_MW = "cost_base_cc_usd_per_ac_mw"
-    COST_SITE_OCC_USD_PER_AC_MW = "cost_site_cc_usd_per_ac_mw"
+    COST_BASE_CC_USD_PER_AC_MW = "cost_base_cc_usd_per_ac_mw"
+    COST_SITE_CC_USD_PER_AC_MW = "cost_site_cc_usd_per_ac_mw"
     COST_BASE_FOC_USD_PER_AC_MW = "cost_base_foc_usd_per_ac_mw"
     COST_SITE_FOC_USD_PER_AC_MW = "cost_site_foc_usd_per_ac_mw"
     COST_BASE_VOC_USD_PER_AC_MW = "cost_base_voc_usd_per_ac_mw"
@@ -266,8 +266,8 @@ class _LegacySCAliases(Enum):
     CONVEX_HULL_AREA = "convex_hull_area"
     CONVEX_HULL_CAPACITY_DENSITY = "convex_hull_capacity_density"
     FULL_CELL_CAPACITY_DENSITY = "full_cell_capacity_density"
-    COST_BASE_OCC_USD_PER_AC_MW = "cost_base_occ_usd_per_ac_mw"
-    COST_SITE_OCC_USD_PER_AC_MW = "cost_site_occ_usd_per_ac_mw"
+    COST_BASE_CC_USD_PER_AC_MW = "cost_base_occ_usd_per_ac_mw"
+    COST_SITE_CC_USD_PER_AC_MW = "cost_site_occ_usd_per_ac_mw"
 
 
 class ModuleName(str, Enum):

--- a/reV/utilities/__init__.py
+++ b/reV/utilities/__init__.py
@@ -151,8 +151,8 @@ class SupplyCurveField(FieldEnum):
     EOS_MULT = "multiplier_cc_eos"
     REG_MULT = "multiplier_cc_regional"
     SC_POINT_ANNUAL_ENERGY_MWH = "annual_energy_site_mwh"
-    COST_BASE_OCC_USD_PER_AC_MW = "cost_base_occ_usd_per_ac_mw"
-    COST_SITE_OCC_USD_PER_AC_MW = "cost_site_occ_usd_per_ac_mw"
+    COST_BASE_OCC_USD_PER_AC_MW = "cost_base_cc_usd_per_ac_mw"
+    COST_SITE_OCC_USD_PER_AC_MW = "cost_site_cc_usd_per_ac_mw"
     COST_BASE_FOC_USD_PER_AC_MW = "cost_base_foc_usd_per_ac_mw"
     COST_SITE_FOC_USD_PER_AC_MW = "cost_site_foc_usd_per_ac_mw"
     COST_BASE_VOC_USD_PER_AC_MW = "cost_base_voc_usd_per_ac_mw"
@@ -266,6 +266,8 @@ class _LegacySCAliases(Enum):
     CONVEX_HULL_AREA = "convex_hull_area"
     CONVEX_HULL_CAPACITY_DENSITY = "convex_hull_capacity_density"
     FULL_CELL_CAPACITY_DENSITY = "full_cell_capacity_density"
+    COST_BASE_OCC_USD_PER_AC_MW = "cost_base_occ_usd_per_ac_mw"
+    COST_SITE_OCC_USD_PER_AC_MW = "cost_site_occ_usd_per_ac_mw"
 
 
 class ModuleName(str, Enum):

--- a/tests/test_bespoke.py
+++ b/tests/test_bespoke.py
@@ -101,8 +101,8 @@ EXPECTED_META_COLUMNS = ["gid",  # needed for H5 collection to work properly
                          SupplyCurveField.SC_POINT_ANNUAL_ENERGY_MWH,
                          SupplyCurveField.EOS_MULT,
                          SupplyCurveField.REG_MULT,
-                         SupplyCurveField.COST_BASE_OCC_USD_PER_AC_MW,
-                         SupplyCurveField.COST_SITE_OCC_USD_PER_AC_MW,
+                         SupplyCurveField.COST_BASE_CC_USD_PER_AC_MW,
+                         SupplyCurveField.COST_SITE_CC_USD_PER_AC_MW,
                          SupplyCurveField.COST_BASE_FOC_USD_PER_AC_MW,
                          SupplyCurveField.COST_SITE_FOC_USD_PER_AC_MW,
                          SupplyCurveField.COST_BASE_VOC_USD_PER_AC_MW,
@@ -678,8 +678,8 @@ def test_bespoke():
                 assert f[dset].any()  # not all zeros
 
         assert not np.allclose(
-            meta[SupplyCurveField.COST_SITE_OCC_USD_PER_AC_MW],
-            meta[SupplyCurveField.COST_BASE_OCC_USD_PER_AC_MW])
+            meta[SupplyCurveField.COST_SITE_CC_USD_PER_AC_MW],
+            meta[SupplyCurveField.COST_BASE_CC_USD_PER_AC_MW])
         assert not np.allclose(
             meta[SupplyCurveField.COST_SITE_FOC_USD_PER_AC_MW],
             meta[SupplyCurveField.COST_BASE_FOC_USD_PER_AC_MW])
@@ -688,7 +688,7 @@ def test_bespoke():
             meta[SupplyCurveField.COST_BASE_VOC_USD_PER_AC_MW])
 
         fcr = meta[SupplyCurveField.FIXED_CHARGE_RATE]
-        cap_cost = (meta[SupplyCurveField.COST_SITE_OCC_USD_PER_AC_MW]
+        cap_cost = (meta[SupplyCurveField.COST_SITE_CC_USD_PER_AC_MW]
                     * meta[SupplyCurveField.CAPACITY_AC_MW])
         foc = (meta[SupplyCurveField.COST_SITE_FOC_USD_PER_AC_MW]
                * meta[SupplyCurveField.CAPACITY_AC_MW])
@@ -697,7 +697,7 @@ def test_bespoke():
         aep = meta[SupplyCurveField.SC_POINT_ANNUAL_ENERGY_MWH]
         lcoe_site = lcoe_fcr(fcr, cap_cost, foc, aep, voc)
 
-        cap_cost = (meta[SupplyCurveField.COST_BASE_OCC_USD_PER_AC_MW]
+        cap_cost = (meta[SupplyCurveField.COST_BASE_CC_USD_PER_AC_MW]
                     * meta[SupplyCurveField.CAPACITY_AC_MW]
                     * meta[SupplyCurveField.REG_MULT]
                     * meta[SupplyCurveField.EOS_MULT])
@@ -1289,8 +1289,8 @@ def test_bespoke_prior_run():
             SupplyCurveField.CONVEX_HULL_AREA,
             SupplyCurveField.CONVEX_HULL_CAPACITY_DENSITY,
             SupplyCurveField.FULL_CELL_CAPACITY_DENSITY,
-            SupplyCurveField.COST_BASE_OCC_USD_PER_AC_MW,
-            SupplyCurveField.COST_SITE_OCC_USD_PER_AC_MW,
+            SupplyCurveField.COST_BASE_CC_USD_PER_AC_MW,
+            SupplyCurveField.COST_SITE_CC_USD_PER_AC_MW,
             SupplyCurveField.COST_BASE_FOC_USD_PER_AC_MW,
             SupplyCurveField.COST_SITE_FOC_USD_PER_AC_MW,
             SupplyCurveField.COST_BASE_VOC_USD_PER_AC_MW,

--- a/tests/test_econ_of_scale.py
+++ b/tests/test_econ_of_scale.py
@@ -202,12 +202,12 @@ def test_econ_of_scale_baseline(request_h5):
                            sc_df[SupplyCurveField.MEAN_LCOE])
         assert (sc_df[SupplyCurveField.EOS_MULT] == 1).all()
         if "mean_capital_cost" in sc_df:
-            capital_cost_per_mw = SupplyCurveField.COST_SITE_OCC_USD_PER_AC_MW
+            capital_cost_per_mw = SupplyCurveField.COST_SITE_CC_USD_PER_AC_MW
             assert np.allclose(sc_df['mean_capital_cost'],
                                sc_df[capital_cost_per_mw]
                                * data["system_capacity"] / 1000)
-        assert np.allclose(sc_df[SupplyCurveField.COST_BASE_OCC_USD_PER_AC_MW],
-                           sc_df[SupplyCurveField.COST_SITE_OCC_USD_PER_AC_MW])
+        assert np.allclose(sc_df[SupplyCurveField.COST_BASE_CC_USD_PER_AC_MW],
+                           sc_df[SupplyCurveField.COST_SITE_CC_USD_PER_AC_MW])
 
 
 def test_sc_agg_econ_scale():

--- a/tests/test_econ_of_scale.py
+++ b/tests/test_econ_of_scale.py
@@ -143,7 +143,6 @@ def test_econ_of_scale_baseline(request_h5):
         h5_dsets = ["capital_cost", "fixed_operating_cost",
                     "fixed_charge_rate", "variable_operating_cost"]
 
-
     with tempfile.TemporaryDirectory() as td:
         gen_temp = os.path.join(td, "ri_my_pv_gen.h5")
         shutil.copy(GEN, gen_temp)

--- a/tests/test_supply_curve_sc_aggregation.py
+++ b/tests/test_supply_curve_sc_aggregation.py
@@ -581,10 +581,10 @@ def test_recalc_lcoe(cap_cost_scale):
                            summary[SupplyCurveField.MEAN_LCOE])
 
     assert np.allclose(summary[SupplyCurveField.EOS_MULT],
-                       summary[SupplyCurveField.COST_SITE_OCC_USD_PER_AC_MW]
-                       / summary[SupplyCurveField.COST_BASE_OCC_USD_PER_AC_MW])
+                       summary[SupplyCurveField.COST_SITE_CC_USD_PER_AC_MW]
+                       / summary[SupplyCurveField.COST_BASE_CC_USD_PER_AC_MW])
     assert np.allclose(data['capital_cost'] / data['system_capacity'] * 1000,
-                       summary[SupplyCurveField.COST_BASE_OCC_USD_PER_AC_MW])
+                       summary[SupplyCurveField.COST_BASE_CC_USD_PER_AC_MW])
 
     expected_recalc_lcoe = lcoe_fcr(data["fixed_charge_rate"],
                                     data["capital_cost"],
@@ -601,7 +601,7 @@ def test_recalc_lcoe(cap_cost_scale):
                                expected_recalc_lcoe)
 
     fcr = summary[SupplyCurveField.FIXED_CHARGE_RATE]
-    cap_cost = (summary[SupplyCurveField.COST_SITE_OCC_USD_PER_AC_MW]
+    cap_cost = (summary[SupplyCurveField.COST_SITE_CC_USD_PER_AC_MW]
                 * summary[SupplyCurveField.CAPACITY_AC_MW])
     foc = (summary[SupplyCurveField.COST_SITE_FOC_USD_PER_AC_MW]
            * summary[SupplyCurveField.CAPACITY_AC_MW])
@@ -612,7 +612,7 @@ def test_recalc_lcoe(cap_cost_scale):
     lcoe = lcoe_fcr(fcr, cap_cost, foc, aep_kwh, voc)
     assert np.allclose(lcoe, summary[SupplyCurveField.MEAN_LCOE])
 
-    cap_cost = (summary[SupplyCurveField.COST_BASE_OCC_USD_PER_AC_MW]
+    cap_cost = (summary[SupplyCurveField.COST_BASE_CC_USD_PER_AC_MW]
                 * summary[SupplyCurveField.CAPACITY_AC_MW]
                 * summary[SupplyCurveField.REG_MULT]
                 * summary[SupplyCurveField.EOS_MULT])


### PR DESCRIPTION
As described in #505, having `occ` in the column name is misleading. In this PR, we update the column name to just say `cc`