### PR TITLE
Allow year in multiple places in resource path

### DIFF
--- a/reV/econ/economies_of_scale.py
+++ b/reV/econ/economies_of_scale.py
@@ -148,7 +148,7 @@ class EconomiesOfScale:
                 continue
 
             delimiters = (">", "<", ">=", "<=", "==", ",", "*", "/", "+",
-                            "-", " ", "(", ")", "[", "]")
+                          "-", " ", "(", ")", "[", "]")
             regex_pattern = "|".join(map(re.escape, delimiters))
             for sub_str in re.split(regex_pattern, str(eq)):
                 is_valid_var_name = (sub_str and not self.is_num(sub_str)

--- a/reV/generation/cli_gen.py
+++ b/reV/generation/cli_gen.py
@@ -67,8 +67,10 @@ def _parse_res_files(res_fps, analysis_years):
 
     # get base filename, may have {} for year format
     if isinstance(res_fps, str) and '{}' in res_fps:
-        # need to make list of res files for each year
-        res_fps = [res_fps.format(year) for year in analysis_years]
+        # make list of res files for each year
+        # .replace("{}", "{0}") used for multiple "{}" in path
+        res_fps = [res_fps.replace("{}", "{0}").format(year)
+                   for year in analysis_years]
     elif isinstance(res_fps, str):
         # only one resource file request, still put in list
         res_fps = [res_fps]


### PR DESCRIPTION
If the resource file path had the year in multiple places, reV gen CLI would previously break. In this PR, we allow the user to specify the year in multiple places in the res fpath.