### PR TITLE
Allow HSDS resoruce files as input to TechMapping

### DIFF
--- a/reV/bespoke/bespoke.py
+++ b/reV/bespoke/bespoke.py
@@ -2500,9 +2500,10 @@ class BespokeWindPlants(BaseAggregation):
             "area_filter_kernel": area_filter_kernel,
             "min_area": min_area,
             "h5_handler": MultiYearWindResource,
+            "hsds": all(check_res_file(fp)[1] for fp in res_fpath),
         }
 
-        with AggFileHandler(excl_fpath, res_fpath[0], **file_kwargs) as fh:
+        with AggFileHandler(excl_fpath, res_fpath, **file_kwargs) as fh:
             n_finished = 0
             for gid in gids:
                 gid_inclusions = cls._get_gid_inclusion_mask(

--- a/reV/config/project_points.py
+++ b/reV/config/project_points.py
@@ -1165,12 +1165,14 @@ class ProjectPoints:
         multi_h5_res, hsds = check_res_file(res_file)
         if multi_h5_res:
             res_cls = MultiFileResourceX
+            res_kwargs = {}
         else:
             res_cls = ResourceX
+            res_kwargs = {"hsds": hsds}
 
         logger.info("Extracting ProjectPoints for desired regions")
         points = []
-        with res_cls(res_file, hsds=hsds) as f:
+        with res_cls(res_file, **res_kwargs) as f:
             meta = f.meta
             for region, region_col in regions.items():
                 logger.debug("- {}: {}".format(region_col, region))
@@ -1182,7 +1184,7 @@ class ProjectPoints:
                     if duplicates:
                         msg = (
                             "reV Cannot currently handle duplicate "
-                            "Resource gids! The given regions containg the "
+                            "Resource gids! The given regions containing the "
                             "same gids:\n{}".format(duplicates)
                         )
                         logger.error(msg)

--- a/reV/supply_curve/aggregation.py
+++ b/reV/supply_curve/aggregation.py
@@ -114,6 +114,7 @@ class AggFileHandler(AbstractAggFileHandler):
         area_filter_kernel="queen",
         min_area=None,
         h5_handler=None,
+        **h5_handler_kwargs,
     ):
         """
         Parameters
@@ -137,6 +138,8 @@ class AggFileHandler(AbstractAggFileHandler):
         h5_handler : rex.Resource | None
             Optional special handler similar to the rex.Resource handler which
             is default.
+        **h5_handler_kwargs
+            Optional keyword-value pairs to pass to the h5 handler.
         """
         super().__init__(
             excl_fpath,
@@ -145,11 +148,10 @@ class AggFileHandler(AbstractAggFileHandler):
             min_area=min_area,
         )
 
-        __, hsds = check_res_file(h5_fpath)
         if h5_handler is None:
-            self._h5 = Resource(h5_fpath, hsds=hsds)
+            self._h5 = Resource(h5_fpath, **h5_handler_kwargs)
         else:
-            self._h5 = h5_handler(h5_fpath, hsds=hsds)
+            self._h5 = h5_handler(h5_fpath, **h5_handler_kwargs)
 
     @property
     def h5(self):
@@ -748,6 +750,7 @@ class Aggregation(BaseAggregation):
             "excl_dict": excl_dict,
             "area_filter_kernel": area_filter_kernel,
             "min_area": min_area,
+            "hsds": check_res_file(h5_fpath)[1],
         }
         dsets = (
             *agg_dset,

--- a/reV/supply_curve/cli_tech_mapping.py
+++ b/reV/supply_curve/cli_tech_mapping.py
@@ -51,7 +51,7 @@ def _validate_dset(config):
         )
 
 
-tm_command = CLICommandFromFunction(TechMapping, method="run",
+tm_command = CLICommandFromFunction(TechMapping.run,
                                     name=str(ModuleName.TECH_MAPPING),
                                     add_collect=False, split_keys=None,
                                     config_preprocessor=_preprocessor)

--- a/reV/supply_curve/cli_tech_mapping.py
+++ b/reV/supply_curve/cli_tech_mapping.py
@@ -4,7 +4,7 @@ reV Tech Mapping CLI utility functions.
 """
 import logging
 
-from gaps.cli import as_click_command, CLICommandFromClass
+from gaps.cli import as_click_command, CLICommandFromFunction
 
 from reV.supply_curve.tech_mapping import TechMapping
 from reV.utilities import ModuleName
@@ -51,10 +51,10 @@ def _validate_dset(config):
         )
 
 
-tm_command = CLICommandFromClass(TechMapping, method="run",
-                                 name=str(ModuleName.TECH_MAPPING),
-                                 add_collect=False, split_keys=None,
-                                 config_preprocessor=_preprocessor)
+tm_command = CLICommandFromFunction(TechMapping, method="run",
+                                    name=str(ModuleName.TECH_MAPPING),
+                                    add_collect=False, split_keys=None,
+                                    config_preprocessor=_preprocessor)
 main = as_click_command(tm_command)
 
 

--- a/reV/supply_curve/cli_tech_mapping.py
+++ b/reV/supply_curve/cli_tech_mapping.py
@@ -4,7 +4,7 @@ reV Tech Mapping CLI utility functions.
 """
 import logging
 
-from gaps.cli import as_click_command, CLICommandFromFunction
+from gaps.cli import as_click_command, CLICommandFromClass
 
 from reV.supply_curve.tech_mapping import TechMapping
 from reV.utilities import ModuleName
@@ -51,10 +51,10 @@ def _validate_dset(config):
         )
 
 
-tm_command = CLICommandFromFunction(TechMapping.run,
-                                    name=str(ModuleName.TECH_MAPPING),
-                                    add_collect=False, split_keys=None,
-                                    config_preprocessor=_preprocessor)
+tm_command = CLICommandFromClass(TechMapping, method="run",
+                                 name=str(ModuleName.TECH_MAPPING),
+                                 add_collect=False, split_keys=None,
+                                 config_preprocessor=_preprocessor)
 main = as_click_command(tm_command)
 
 

--- a/reV/supply_curve/points.py
+++ b/reV/supply_curve/points.py
@@ -11,7 +11,7 @@ import numpy as np
 import pandas as pd
 from rex.multi_time_resource import MultiTimeResource
 from rex.resource import BaseResource, Resource
-from rex.utilities.utilities import jsonify_dict
+from rex.utilities.utilities import jsonify_dict, check_res_file
 
 from reV.econ.economies_of_scale import EconomiesOfScale
 from reV.econ.utilities import lcoe_fcr
@@ -1169,9 +1169,11 @@ class AggregationSupplyCurvePoint(SupplyCurvePoint):
             Resource h5 handler object.
         """
         if self._h5 is None and "*" in self._h5_fpath:
-            self._h5 = MultiTimeResource(self._h5_fpath)
+            __, hsds = check_res_file(self._h5_fpath)
+            self._h5 = MultiTimeResource(self._h5_fpath, hsds=hsds)
         elif self._h5 is None:
-            self._h5 = Resource(self._h5_fpath)
+            __, hsds = check_res_file(self._h5_fpath)
+            self._h5 = Resource(self._h5_fpath, hsds=hsds)
 
         return self._h5
 
@@ -1643,7 +1645,8 @@ class GenerationSupplyCurvePoint(AggregationSupplyCurvePoint):
             reV generation Resource object
         """
         if self._gen is None:
-            self._gen = Resource(self._gen_fpath, str_decode=False)
+            __, hsds = check_res_file(self._gen_fpath)
+            self._gen = Resource(self._gen_fpath, str_decode=False, hsds=hsds)
 
         return self._gen
 

--- a/reV/supply_curve/sc_aggregation.py
+++ b/reV/supply_curve/sc_aggregation.py
@@ -570,14 +570,19 @@ class SupplyCurveAggregation(BaseAggregation):
             ``False``, the mean LCOE will be computed from the data
             stored under the `lcoe_dset` instead. By default, ``True``.
         zones_dset : str, optional
-            Dataset name in `excl_fpath` containing the zones to be applied.
-            If specified, supply curve aggregation will be performed separately
-            for each discrete zone within each supply curve site. This option
-            can be used for uses cases such as subdividing sites by parcel,
-            such that each parcel within each site is output to a separate
-            sc_gid. The input data layer should consist of unique integer
-            values for each zone. Values of zero will be treated as excluded
-            areas.
+            Dataset name in `excl_fpath` containing the zones to be
+            applied. If specified, supply curve aggregation will be
+            performed separately for each discrete zone within each
+            supply curve site. This option can be used for uses cases
+            such as subdividing sites by parcel, such that each parcel
+            within each site is output to a separate ``sc_gid``. The
+            input data layer should consist of unique integer values for
+            each zone. Values of zero will be treated as excluded areas.
+            This functionality works best of you have on the order of
+            ~100,000 zones or less. If you have significantly more zones
+            than that, the supply curve aggregation computation may take
+            too long to run; consider performing an alternative
+            analysis. By default, ``None``.
 
         Examples
         --------

--- a/reV/supply_curve/tech_mapping.py
+++ b/reV/supply_curve/tech_mapping.py
@@ -16,10 +16,10 @@ from warnings import warn
 
 import h5py
 import numpy as np
+from scipy.spatial import cKDTree
 from rex.resource import Resource
 from rex.utilities.execution import SpawnProcessPool
-from rex.utilities.utilities import res_dist_threshold
-from scipy.spatial import cKDTree
+from rex.utilities.utilities import check_res_file, res_dist_threshold
 
 from reV.supply_curve.extent import SupplyCurveExtent, LATITUDE, LONGITUDE
 from reV.utilities.exceptions import FileInputError, FileInputWarning
@@ -92,7 +92,8 @@ class TechMapping:
             of the diagonal between closest resource points, with desired
             extra margin
         """
-        with Resource(res_fpath) as f:
+        __, hsds = check_res_file(res_fpath)
+        with Resource(res_fpath, hsds=hsds) as f:
             lat_lons = f.lat_lon
 
         # pylint: disable=not-callable

--- a/reV/version.py
+++ b/reV/version.py
@@ -2,4 +2,4 @@
 reV Version number
 """
 
-__version__ = "0.14.0"
+__version__ = "0.14.1"

--- a/tests/test_supply_curve_tech_mapping.py
+++ b/tests/test_supply_curve_tech_mapping.py
@@ -37,11 +37,15 @@ TM_DSET = 'techmap_nsrdb_ri_truth'
 def test_resource_tech_mapping(tmp_path, batch_size, sc_resolution):
     """Run the supply curve technology mapping and compare to baseline file"""
 
+    dset = "tm"
+
     excl_fpath = EXCL
     excl_fpath = tmp_path.joinpath("excl.h5").as_posix()
     shutil.copy(EXCL, excl_fpath)
 
-    dset = "tm"
+    with ExclusionLayers(excl_fpath) as out:
+        assert dset not in out, "Techmap dataset already exists in H5"
+
     TechMapping.run(
         excl_fpath, RES, dset=dset, max_workers=2, sc_resolution=sc_resolution,
         batch_size=batch_size,

--- a/tests/test_supply_curve_tech_mapping.py
+++ b/tests/test_supply_curve_tech_mapping.py
@@ -57,12 +57,16 @@ def test_resource_tech_mapping(tmp_path, batch_size, sc_resolution):
     with ExclusionLayers(excl_fpath) as out:
         assert dset in out, "Techmap dataset was not written to H5"
         ind = out[dset]
+        attrs = out.h5.attrs[dset]
 
     msg = 'Tech mapping failed for index mappings vs. baseline results.'
     assert np.allclose(ind, ind_truth), msg
 
     msg = 'Tech mapping didnt find all 100 generation points!'
     assert len(set(ind.flatten())) == 101, msg
+
+    assert attrs["src_res_fpath"] == RES
+    assert np.isclose(attrs["distance_threshold"], 0.029, atol=0.001)
 
 
 def test_tech_mapping_cli(runner, clear_loggers, tmp_path):


### PR DESCRIPTION
When performing techmapping operations and base aggregation methods, we now check for an HSDS resource file and pass the correct keyword if necessary.