### PR TITLE
Update grid spacing computation logic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,10 @@ classifiers=[
   "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-  "NREL-gaps>=0.8.0,<0.9",
-  "NREL-NRWAL>=0.0.11,<0.1",
+  "NREL-gaps>=0.8.0",
+  "NREL-NRWAL>=0.0.11",
   "NREL-PySAM~=7.0.0",
-  "NREL-rex>=0.3.5,<0.4",
+  "NREL-rex>=0.4.0",
   "numpy>=2.0.2,<3",
   "packaging>=24.2,<25",
   "plotly>=6.0.1,<7",

--- a/reV/supply_curve/extent.py
+++ b/reV/supply_curve/extent.py
@@ -297,14 +297,19 @@ class SupplyCurveExtent:
             lats = []
             lons = []
 
+            max_center = self.resolution // 2 + 1
+            min_center = max_center - 2 + self.resolution % 2
+
             sc_cols, sc_rows = np.meshgrid(
                 np.arange(self.n_cols), np.arange(self.n_rows)
             )
             for r, c in zip(sc_rows.flatten(), sc_cols.flatten()):
-                r = self.excl_row_slices[r]
-                c = self.excl_col_slices[c]
-                lats.append(self.exclusions[LATITUDE, r, c].mean())
-                lons.append(self.exclusions[LONGITUDE, r, c].mean())
+                r = slice(r * self.resolution + min_center,
+                          r * self.resolution + max_center)
+                c = slice(c * self.resolution + min_center,
+                          c * self.resolution + max_center)
+                lats.append(np.median(self.exclusions[LATITUDE, r, c]))
+                lons.append(np.median(self.exclusions[LONGITUDE, r, c]))
 
             self._latitude = np.array(lats, dtype="float32")
             self._longitude = np.array(lons, dtype="float32")
@@ -324,14 +329,19 @@ class SupplyCurveExtent:
             lats = []
             lons = []
 
+            max_center = self.resolution // 2 + 1
+            min_center = max_center - 2 + self.resolution % 2
+
             sc_cols, sc_rows = np.meshgrid(
                 np.arange(self.n_cols), np.arange(self.n_rows)
             )
             for r, c in zip(sc_rows.flatten(), sc_cols.flatten()):
-                r = self.excl_row_slices[r]
-                c = self.excl_col_slices[c]
-                lats.append(self.exclusions[LATITUDE, r, c].mean())
-                lons.append(self.exclusions[LONGITUDE, r, c].mean())
+                r = slice(r * self.resolution + min_center,
+                          r * self.resolution + max_center)
+                c = slice(c * self.resolution + min_center,
+                          c * self.resolution + max_center)
+                lats.append(np.median(self.exclusions[LATITUDE, r, c]))
+                lons.append(np.median(self.exclusions[LONGITUDE, r, c]))
 
             self._latitude = np.array(lats, dtype="float32")
             self._longitude = np.array(lons, dtype="float32")


### PR DESCRIPTION
Taking the mean lat/lon values over a large space can lead to imprecisions in the output supply curve lat/lon. In this PR, we adjust the computation to take the median lat/lon of the pixels in the center of the supply curve. This can still lead to imprecisions  if each grid cell is very large, but should be a decent approximation at typical reV exclusion resolutions (90m). 

There is a corresponding PR in `reVX` here (link TBA) to recompute the "exact" lat/lon centers using `pyproj`. If "exact" precision is needed, you can add the `reVX` command line call as a pipeline step right after computing the supply curve.