### PR TITLE
Actually allow using `self.wind_plant` in bespoke functions

### DIFF
--- a/reV/bespoke/bespoke.py
+++ b/reV/bespoke/bespoke.py
@@ -1282,6 +1282,14 @@ class BespokeSinglePlant:
             for k, v in plant.outputs.items():
                 self._outputs[k + "-{}".format(year)] = v
 
+        self._compute_output_means()
+        self._add_extra_meta_columns()
+        logger.debug("Timeseries analysis complete!")
+
+        return self.outputs
+
+    def _compute_output_means(self):
+        """Compute time series means and store them in the outputs dict"""
         means = {}
         for k1, v1 in self._outputs.items():
             if isinstance(v1, Number) and parse_year(k1, option="boolean"):
@@ -1293,6 +1301,9 @@ class BespokeSinglePlant:
                 means[base_str + "means"] = np.mean(all_values)
 
         self._outputs.update(means)
+
+    def _add_extra_meta_columns(self):
+        """Copy over some non-temporal datasets to meta"""
 
         self._meta[SupplyCurveField.MEAN_RES] = self.res_df["windspeed"].mean()
         self._meta[SupplyCurveField.MEAN_CF_DC] = np.nan
@@ -1318,10 +1329,6 @@ class BespokeSinglePlant:
             self._meta[SupplyCurveField.WAKE_LOSSES] = (
                 self.outputs["annual_wake_loss_internal_percent-means"]
             )
-
-        logger.debug("Timeseries analysis complete!")
-
-        return self.outputs
 
     def run_plant_optimization(self):
         """Run the wind plant layout optimization and export outputs

--- a/reV/bespoke/bespoke.py
+++ b/reV/bespoke/bespoke.py
@@ -310,7 +310,24 @@ class BespokeSinglePlant:
                   cost ($) as evaluated by
                   `balance_of_system_cost_function`
                 - ``self.wind_plant``: the SAM wind plant object,
-                  through which all SAM variables can be accessed
+                  through which all SAM variables can be accessed.
+
+                  .. IMPORTANT::
+                     When using the `self.wind_plant` variable,
+                     DO NOT include quotes around variable names (keys).
+
+                        - ❌ Wrong: ``self.wind_plant["annual_energy"]``
+                        - ✅ Correct: ``self.wind_plant[annual_energy]``
+
+                  .. IMPORTANT::
+                     It's possible for SAM wind plant variables to be
+                     ``None``, especially if something went wrong while
+                     optimizing the wind plant layout. In this case,
+                     your objective function may fail to evaluate and
+                     terminate the program entirely. To avoid this, add
+                     a default value for the variable in your objective
+                     function, like so:
+                     ``(self.wind_plant[annual_energy] or 0)``
 
         capital_cost_function : str
             The plant capital cost function as a string, must return the total
@@ -1626,7 +1643,24 @@ class BespokeWindPlants(BaseAggregation):
                   cost ($) as evaluated by
                   `balance_of_system_cost_function`
                 - ``self.wind_plant``: the SAM wind plant object,
-                  through which all SAM variables can be accessed
+                  through which all SAM variables can be accessed.
+
+                  .. IMPORTANT::
+                     When using the `self.wind_plant` variable,
+                     DO NOT include quotes around variable names (keys).
+
+                        - ❌ Wrong: ``self.wind_plant["annual_energy"]``
+                        - ✅ Correct: ``self.wind_plant[annual_energy]``
+
+                  .. IMPORTANT::
+                     It's possible for SAM wind plant variables to be
+                     ``None``, especially if something went wrong while
+                     optimizing the wind plant layout. In this case,
+                     your objective function may fail to evaluate and
+                     terminate the program entirely. To avoid this, add
+                     a default value for the variable in your objective
+                     function, like so:
+                     ``(self.wind_plant[annual_energy] or 0)``
 
         capital_cost_function : str
             The plant capital cost function written out as a string.

--- a/reV/bespoke/place_turbines.py
+++ b/reV/bespoke/place_turbines.py
@@ -3,6 +3,7 @@
 """
 place turbines for bespoke wind plants
 """
+import re
 from functools import wraps
 
 import numpy as np
@@ -133,13 +134,15 @@ class PlaceTurbines:
         # inputs
         self.wind_plant = wind_plant
 
-        self.capital_cost_function = capital_cost_function
-        self.fixed_operating_cost_function = fixed_operating_cost_function
-        self.variable_operating_cost_function = \
-            variable_operating_cost_function
-        self.balance_of_system_cost_function = balance_of_system_cost_function
+        self.capital_cost_function = _fix_wp_keys(capital_cost_function)
+        self.fixed_operating_cost_function = _fix_wp_keys(
+            fixed_operating_cost_function)
+        self.variable_operating_cost_function = _fix_wp_keys(
+            variable_operating_cost_function)
+        self.balance_of_system_cost_function = _fix_wp_keys(
+            balance_of_system_cost_function)
 
-        self.objective_function = objective_function
+        self.objective_function = _fix_wp_keys(objective_function)
         self.include_mask = include_mask
         self.pixel_side_length = pixel_side_length
         self.min_spacing = min_spacing
@@ -158,7 +161,6 @@ class PlaceTurbines:
         self.safe_polygons = None
         self._optimized_nn_conn_dist_m = None
 
-        self.ILLEGAL = ('import ', 'os.', 'sys.', '.__', '__.', 'eval', 'exec')
         self._preflight(self.objective_function)
         self._preflight(self.capital_cost_function)
         self._preflight(self.fixed_operating_cost_function)
@@ -167,7 +169,10 @@ class PlaceTurbines:
 
     def _preflight(self, eqn):
         """Run preflight checks on the equation string."""
-        for substr in self.ILLEGAL:
+        _illegal_substr = ('import ', 'os.', 'sys.', '.__', '__.', 'eval',
+                           'exec')
+
+        for substr in _illegal_substr:
             if substr in str(eqn):
                 msg = ('Will not evaluate string which contains "{}": {}'
                        .format(substr, eqn))
@@ -656,3 +661,10 @@ def _compute_nn_conn_dist(x_coords, y_coords):
         left_to_connect.mask[next_connection] = 1
 
     return total_dist
+
+
+def _fix_wp_keys(eqn):
+    """Surround key of `self.wind_plant` in quotes"""
+    pattern = r'(self\.wind_plant\[\s*)([^\]]+?)(\s*\])'
+    replacement = r'\1"\2"\3'
+    return re.sub(pattern, replacement, str(eqn))

--- a/reV/bespoke/place_turbines.py
+++ b/reV/bespoke/place_turbines.py
@@ -97,7 +97,24 @@ class PlaceTurbines:
                   cost ($) as evaluated by
                   `balance_of_system_cost_function`
                 - ``self.wind_plant``: the SAM wind plant object,
-                  through which all SAM variables can be accessed
+                  through which all SAM variables can be accessed.
+
+                  .. IMPORTANT::
+                     When using the `self.wind_plant` variable,
+                     DO NOT include quotes around variable names (keys).
+
+                        - ❌ Wrong: ``self.wind_plant["annual_energy"]``
+                        - ✅ Correct: ``self.wind_plant[annual_energy]``
+
+                  .. IMPORTANT::
+                     It's possible for SAM wind plant variables to be
+                     ``None``, especially if something went wrong while
+                     optimizing the wind plant layout. In this case,
+                     your objective function may fail to evaluate and
+                     terminate the program entirely. To avoid this, add
+                     a default value for the variable in your objective
+                     function, like so:
+                     ``(self.wind_plant[annual_energy] or 0)``
 
         capital_cost_function : str
             The plant capital cost function as a string, must return the

--- a/reV/supply_curve/tech_mapping.py
+++ b/reV/supply_curve/tech_mapping.py
@@ -32,6 +32,7 @@ class TechMapping:
 
     def __init__(self, excl_fpath, sc_resolution=1200):
         """
+
         Parameters
         ----------
         excl_fpath : str
@@ -44,9 +45,9 @@ class TechMapping:
             map the exclusion pixels in 1200x1200 pixel chunks.
 
             .. Note:: This parameter does not affect the exclusion to resource
-            (tech) mapping, which deviates from how the effect of the
-            ``sc_resolution`` parameter works in other functionality within
-            ``reV``.
+                      (tech) mapping, which deviates from how the effect of the
+                      ``sc_resolution`` parameter works in other functionality
+                      within ``reV``.
 
         """
         self._excl_fpath = excl_fpath
@@ -433,7 +434,7 @@ class TechMapping:
             techmap (exclusions-to-resource mapping data) will be saved.
 
             .. Important:: If this dataset already exists in the h5 file,
-              it will be overwritten.
+                           it will be overwritten.
 
         sc_resolution : int | None, optional
             Defines how many exclusion pixels are mapped at a time. Units
@@ -442,9 +443,9 @@ class TechMapping:
             map the exclusion pixels in 1200x1200 pixel chunks.
 
             .. Note:: This parameter does not affect the exclusion to resource
-            (tech) mapping, which deviates from how the effect of the
-            ``sc_resolution`` parameter works in other functionality within
-            ``reV``.
+                      (tech) mapping, which deviates from how the effect of the
+                      ``sc_resolution`` parameter works in other functionality
+                      within ``reV``.
 
         dist_margin : float, optional
             Extra margin to multiply times the computed distance between


### PR DESCRIPTION
Although it wad advertised that users could use `self.wind_plant` in their objective functions, in practice this broke when passing the function thought the CLI. The technical reason for this has to do with quote escaping, and the easiest fix was to remove the quotes requirements from the `wind_plant` keys on the user side (they are added back into the objective function right before getting evaluated. 