### PR TITLE
Config files in output file attributes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -218,6 +218,6 @@ Potential (reV) Model: A Geospatial Platform for Technical Potential and Supply
 Curve Modeling.” Golden, Colorado, United States: National Renewable Energy
 Laboratory. NREL/TP-6A20-73067. https://doi.org/10.2172/1563140.
 
-Grant Buster, Michael Rossol, Paul Pinchuk, Brandon N Benton, Robert Spencer,
-Mike Bannister, & Travis Williams. (2023).
-NREL/reV: reV 0.8.0 (v0.8.0). Zenodo. https://doi.org/10.5281/zenodo.8247528
+Buster, G., Pinchuk, P., Rossol, M., Benton, B., Gleason, M., Stanley, A. P.,
+Spencer, R., Bannister, M., & Williams, T. (2020). reV (Version 0.14.5)
+[Computer software]. https://github.com/NREL/reV

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers=[
   "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-  "NREL-gaps>=0.8.0",
+  "NREL-gaps>=0.8.11",
   "NREL-NRWAL>=0.0.11",
   "NREL-PySAM~=7.0.0",
   "NREL-rex>=0.4.0",

--- a/reV/econ/econ.py
+++ b/reV/econ/econ.py
@@ -498,7 +498,7 @@ class Econ(BaseGen):
         return data_shape
 
     def run(self, out_fpath=None, max_workers=1, timeout=1800, pool_size=None,
-            config_file=None, project_dir=None):
+            config_file=None):
         """Execute a parallel reV econ run with smart data flushing.
 
         Parameters
@@ -524,10 +524,6 @@ class Econ(BaseGen):
             Path to config file used for this econ run (if applicable).
             This is used to store information about the run in the
             output file attrs. By default, ``None``.
-        project_dir : str, optional
-            Path to run directory used for this econ run (if
-            applicable). This is used to store information about the run
-            in the output file attrs. By default, ``None``.
 
         Returns
         -------
@@ -545,8 +541,7 @@ class Econ(BaseGen):
             self._init_fpath(out_fpath, ModuleName.ECON)
 
         self._init_h5(mode="a" if self._append else "w",
-                      config_file=config_file, project_dir=project_dir,
-                      module=ModuleName.ECON)
+                      config_file=config_file, module=ModuleName.ECON)
         self._init_out_arrays()
 
         diff = list(set(self.points_control.sites)

--- a/reV/econ/econ.py
+++ b/reV/econ/econ.py
@@ -497,7 +497,8 @@ class Econ(BaseGen):
 
         return data_shape
 
-    def run(self, out_fpath=None, max_workers=1, timeout=1800, pool_size=None):
+    def run(self, out_fpath=None, max_workers=1, timeout=1800, pool_size=None,
+            config_file=None, project_dir=None):
         """Execute a parallel reV econ run with smart data flushing.
 
         Parameters
@@ -519,6 +520,14 @@ class Econ(BaseGen):
             Number of futures to submit to a single process pool for
             parallel futures. If ``None``, the pool size is set to
             ``os.cpu_count() * 2``. By default, ``None``.
+        config_file : str, optional
+            Path to config file used for this econ run (if applicable).
+            This is used to store information about the run in the
+            output file attrs. By default, ``None``.
+        project_dir : str, optional
+            Path to run directory used for this econ run (if
+            applicable). This is used to store information about the run
+            in the output file attrs. By default, ``None``.
 
         Returns
         -------
@@ -535,7 +544,9 @@ class Econ(BaseGen):
         else:
             self._init_fpath(out_fpath, ModuleName.ECON)
 
-        self._init_h5(mode="a" if self._append else "w")
+        self._init_h5(mode="a" if self._append else "w",
+                      config_file=config_file, project_dir=project_dir,
+                      module=ModuleName.ECON)
         self._init_out_arrays()
 
         diff = list(set(self.points_control.sites)

--- a/reV/generation/base.py
+++ b/reV/generation/base.py
@@ -1051,8 +1051,7 @@ class BaseGen(ABC):
             ti = None
 
         run_attrs = add_to_run_attrs(run_attrs=self.run_attrs,
-                                     config_file=config_file,
-                                     module=ModuleName.GENERATION)
+                                     config_file=config_file, module=module)
 
         Outputs.init_h5(
             self._out_fpath,

--- a/reV/generation/base.py
+++ b/reV/generation/base.py
@@ -994,7 +994,7 @@ class BaseGen(ABC):
         self._out_fpath = os.path.join(project_dir, out_fn)
         self._run_attrs["out_fpath"] = out_fpath
 
-    def _init_h5(self, mode="w"):
+    def _init_h5(self, mode="w", config_file=None, project_dir=None):
         """Initialize the single h5 output file with all output requests.
 
         Parameters
@@ -1048,6 +1048,13 @@ class BaseGen(ABC):
         else:
             ti = None
 
+        run_attrs = copy.deepcopy(self.run_attrs)
+        run_attrs["run_directory"] = str(project_dir)
+        run_attrs["generation_config"] = "{}"
+        if config_file and os.path.exists(config_file):
+            with open(config_file, "r") as fh:
+                run_attrs["generation_config"] = fh.read()
+
         Outputs.init_h5(
             self._out_fpath,
             self.output_request,
@@ -1058,7 +1065,7 @@ class BaseGen(ABC):
             self.meta,
             time_index=ti,
             configs=self.sam_metas,
-            run_attrs=self.run_attrs,
+            run_attrs=run_attrs,
             mode=mode,
         )
 

--- a/reV/generation/base.py
+++ b/reV/generation/base.py
@@ -994,7 +994,8 @@ class BaseGen(ABC):
         self._out_fpath = os.path.join(project_dir, out_fn)
         self._run_attrs["out_fpath"] = out_fpath
 
-    def _init_h5(self, mode="w", config_file=None, project_dir=None):
+    def _init_h5(self, mode="w", config_file=None, project_dir=None,
+                 module=ModuleName.GENERATION):
         """Initialize the single h5 output file with all output requests.
 
         Parameters
@@ -1050,10 +1051,10 @@ class BaseGen(ABC):
 
         run_attrs = copy.deepcopy(self.run_attrs)
         run_attrs["run_directory"] = str(project_dir)
-        run_attrs["generation_config"] = "{}"
+        run_attrs[f"{module}_config"] = "{}"
         if config_file and os.path.exists(config_file):
             with open(config_file, "r") as fh:
-                run_attrs["generation_config"] = fh.read()
+                run_attrs[f"{module}_config"] = fh.read()
 
         Outputs.init_h5(
             self._out_fpath,

--- a/reV/generation/base.py
+++ b/reV/generation/base.py
@@ -995,7 +995,7 @@ class BaseGen(ABC):
         self._out_fpath = os.path.join(project_dir, out_fn)
         self._run_attrs["out_fpath"] = out_fpath
 
-    def _init_h5(self, mode="w", config_file=None, project_dir=None,
+    def _init_h5(self, mode="w", config_file=None,
                  module=ModuleName.GENERATION):
         """Initialize the single h5 output file with all output requests.
 
@@ -1052,7 +1052,6 @@ class BaseGen(ABC):
 
         run_attrs = add_to_run_attrs(run_attrs=self.run_attrs,
                                      config_file=config_file,
-                                     project_dir=project_dir,
                                      module=ModuleName.GENERATION)
 
         Outputs.init_h5(

--- a/reV/generation/base.py
+++ b/reV/generation/base.py
@@ -28,6 +28,7 @@ from reV.utilities.exceptions import (
     OutputWarning,
     ParallelExecutionWarning,
 )
+from reV.utilities.cli_functions import add_to_run_attrs
 
 logger = logging.getLogger(__name__)
 
@@ -1049,12 +1050,10 @@ class BaseGen(ABC):
         else:
             ti = None
 
-        run_attrs = copy.deepcopy(self.run_attrs)
-        run_attrs["run_directory"] = str(project_dir)
-        run_attrs[f"{module}_config"] = "{}"
-        if config_file and os.path.exists(config_file):
-            with open(config_file, "r") as fh:
-                run_attrs[f"{module}_config"] = fh.read()
+        run_attrs = add_to_run_attrs(run_attrs=self.run_attrs,
+                                     config_file=config_file,
+                                     project_dir=project_dir,
+                                     module=ModuleName.GENERATION)
 
         Outputs.init_h5(
             self._out_fpath,

--- a/reV/generation/generation.py
+++ b/reV/generation/generation.py
@@ -455,6 +455,7 @@ class Gen(BaseGen):
         self._sam_module = self.OPTIONS[self.tech]
         self._run_attrs["sam_module"] = self._sam_module.MODULE
         self._run_attrs["res_file"] = resource_file
+        self._run_attrs["low_res_resource_file"] = str(low_res_resource_file)
 
         self._multi_h5_res, self._hsds = check_res_file(resource_file)
         self._gid_map = self._parse_gid_map(gid_map)

--- a/reV/generation/generation.py
+++ b/reV/generation/generation.py
@@ -1045,7 +1045,7 @@ class Gen(BaseGen):
         return kwargs
 
     def run(self, out_fpath=None, max_workers=1, timeout=1800, pool_size=None,
-            config_file=None, project_dir=None):
+            config_file=None):
         """Execute a parallel reV generation run with smart data flushing.
 
         Parameters
@@ -1073,10 +1073,6 @@ class Gen(BaseGen):
             Path to config file used for this generation run (if
             applicable). This is used to store information about the run
             in the output file attrs. By default, ``None``.
-        project_dir : str, optional
-            Path to run directory used for this generation run (if
-            applicable). This is used to store information about the run
-            in the output file attrs. By default, ``None``.
 
         Returns
         -------
@@ -1086,7 +1082,7 @@ class Gen(BaseGen):
         """
         # initialize output file
         self._init_fpath(out_fpath, module=ModuleName.GENERATION)
-        self._init_h5(config_file=config_file, project_dir=project_dir)
+        self._init_h5(config_file=config_file, module=ModuleName.GENERATION)
         self._init_out_arrays()
         if pool_size is None:
             pool_size = os.cpu_count() * 2

--- a/reV/generation/generation.py
+++ b/reV/generation/generation.py
@@ -1044,7 +1044,8 @@ class Gen(BaseGen):
 
         return kwargs
 
-    def run(self, out_fpath=None, max_workers=1, timeout=1800, pool_size=None):
+    def run(self, out_fpath=None, max_workers=1, timeout=1800, pool_size=None,
+            config_file=None, project_dir=None):
         """Execute a parallel reV generation run with smart data flushing.
 
         Parameters
@@ -1068,6 +1069,14 @@ class Gen(BaseGen):
             Number of futures to submit to a single process pool for
             parallel futures. If ``None``, the pool size is set to
             ``os.cpu_count() * 2``. By default, ``None``.
+        config_file : str, optional
+            Path to config file used for this generation run (if
+            applicable). This is used to store information about the run
+            in the output file attrs. By default, ``None``.
+        project_dir : str, optional
+            Path to run directory used for this generation run (if
+            applicable). This is used to store information about the run
+            in the output file attrs. By default, ``None``.
 
         Returns
         -------
@@ -1077,7 +1086,7 @@ class Gen(BaseGen):
         """
         # initialize output file
         self._init_fpath(out_fpath, module=ModuleName.GENERATION)
-        self._init_h5()
+        self._init_h5(config_file=config_file, project_dir=project_dir)
         self._init_out_arrays()
         if pool_size is None:
             pool_size = os.cpu_count() * 2

--- a/reV/handlers/multi_year.py
+++ b/reV/handlers/multi_year.py
@@ -199,7 +199,7 @@ class MultiYearGroup:
         """
         Returns
         -------
-        _dsets :list | tuple
+        _dsets : list | tuple
             Datasets to collect
         """
         return self._dsets

--- a/reV/handlers/multi_year.py
+++ b/reV/handlers/multi_year.py
@@ -2,6 +2,7 @@
 """
 Classes to collect reV outputs from multiple annual files.
 """
+import json
 import glob
 import logging
 import os
@@ -23,6 +24,7 @@ from reV.config.output_request import SAMOutputRequest
 from reV.handlers.outputs import Outputs
 from reV.utilities import ModuleName, log_versions
 from reV.utilities.exceptions import ConfigError, HandlerRuntimeError
+from reV.utilities.cli_functions import add_to_run_attrs
 
 logger = logging.getLogger(__name__)
 
@@ -413,7 +415,8 @@ class MultiYear(Outputs):
 
         return source_files
 
-    def collect(self, source_files, dset, profiles=False, pass_through=False):
+    def collect(self, source_files, dset, profiles=False, pass_through=False,
+                config_file=None):
         """
         Collect dataset dset from given list of h5 files
 
@@ -433,15 +436,24 @@ class MultiYear(Outputs):
         pass_through : bool
             Flag to just pass through dataset without name modifications
             (no differences between years, no means or stdevs)
+        config_file : str, optional
+            Path to config file used for this multi-year collection run
+            (if applicable). This is used to store information about the
+            run in the output file attrs. By default, ``None``.
         """
         source_files = self.parse_source_files_pattern(source_files)
         with Outputs(source_files[0], mode='r') as f_in:
+            global_attrs = f_in.get_attrs()
+            meta_attrs = f_in.get_attrs("meta")
             meta = f_in.h5['meta'][...]
 
         if 'meta' not in self.datasets:
             logger.debug("Copying meta")
             self._create_dset('meta', meta.shape, meta.dtype,
-                              data=meta)
+                              data=meta, attrs=meta_attrs)
+
+        self._copy_global_attrs(global_attrs, source_files,
+                                config_file=config_file)
 
         meta = pd.DataFrame(meta)
         for year_h5 in source_files:
@@ -450,6 +462,19 @@ class MultiYear(Outputs):
 
             self._copy_dset(year_h5, dset, meta=meta,
                             pass_through=pass_through)
+
+    def _copy_global_attrs(self, global_attrs, source_files, config_file=None):
+        """Copy global attrs to file"""
+        prefix = (f"{self._group}_{ModuleName.MULTI_YEAR}"
+                  if self._group else f"{ModuleName.MULTI_YEAR}")
+
+        run_attrs = add_to_run_attrs(run_attrs=global_attrs,
+                                     config_file=config_file, module=prefix)
+
+        run_attrs[f"{prefix}_source_files"] = json.dumps(source_files)
+
+        for key, value in run_attrs.items():
+            self.h5.attrs[key] = value
 
     def _get_source_dsets(self, dset_out):
         """
@@ -658,7 +683,8 @@ class MultiYear(Outputs):
         return len(shape) == 2
 
     @classmethod
-    def pass_through(cls, my_file, source_files, dset, group=None):
+    def pass_through(cls, my_file, source_files, dset, group=None,
+                     config_file=None):
         """
         Pass through a dataset that is identical in all source files to a
         dataset of the same name in the output multi-year file.
@@ -678,15 +704,21 @@ class MultiYear(Outputs):
             dataset in my_file)
         group : str
             Group to collect datasets into
+        config_file : str, optional
+            Path to config file used for this multi-year collection run
+            (if applicable). This is used to store information about the
+            run in the output file attrs. By default, ``None``.
         """
         source_files = cls.parse_source_files_pattern(source_files)
         logger.info('Passing through {} into {}.'
                     .format(dset, my_file))
         with cls(my_file, mode='a', group=group) as my:
-            my.collect(source_files, dset, pass_through=True)
+            my.collect(source_files, dset, pass_through=True,
+                       config_file=config_file)
 
     @classmethod
-    def collect_means(cls, my_file, source_files, dset, group=None):
+    def collect_means(cls, my_file, source_files, dset, group=None,
+                      config_file=None):
         """
         Collect and compute multi-year means for given dataset
 
@@ -704,18 +736,23 @@ class MultiYear(Outputs):
             Dataset to collect
         group : str
             Group to collect datasets into
+        config_file : str, optional
+            Path to config file used for this multi-year collection run
+            (if applicable). This is used to store information about the
+            run in the output file attrs. By default, ``None``.
         """
         logger.info('Collecting {} into {} '
                     'and computing multi-year means and standard deviations.'
                     .format(dset, my_file))
         source_files = cls.parse_source_files_pattern(source_files)
         with cls(my_file, mode='a', group=group) as my:
-            my.collect(source_files, dset)
+            my.collect(source_files, dset, config_file=config_file)
             means = my._compute_means("{}-means".format(dset))
             my._compute_stdev("{}-stdev".format(dset), means=means)
 
     @classmethod
-    def collect_profiles(cls, my_file, source_files, dset, group=None):
+    def collect_profiles(cls, my_file, source_files, dset, group=None,
+                         config_file=None):
         """
         Collect multi-year profiles associated with given dataset
 
@@ -733,14 +770,19 @@ class MultiYear(Outputs):
             Profiles dataset to collect
         group : str
             Group to collect datasets into
+        config_file : str, optional
+            Path to config file used for this multi-year collection run
+            (if applicable). This is used to store information about the
+            run in the output file attrs. By default, ``None``.
         """
         logger.info('Collecting {} into {}'.format(dset, my_file))
         source_files = cls.parse_source_files_pattern(source_files)
         with cls(my_file, mode='a', group=group) as my:
-            my.collect(source_files, dset, profiles=True)
+            my.collect(source_files, dset, profiles=True,
+                       config_file=config_file)
 
 
-def my_collect_groups(out_fpath, groups, clobber=True):
+def my_collect_groups(out_fpath, groups, clobber=True, config_file=None):
     """Collect all groups into a single multi-year HDF5 file.
 
     ``reV`` multi-year combines ``reV`` generation data from multiple
@@ -808,6 +850,10 @@ def my_collect_groups(out_fpath, groups, clobber=True):
         single-year files. If ``False``, then datasets in the existing
         file will **not** be overwritten with (potentially new/updated)
         data from the single-year files. By default, ``True``.
+    config_file : str, optional
+        Path to config file used for this multi-year collection run
+        (if applicable). This is used to store information about the
+        run in the output file attrs. By default, ``None``.
     """
     if not out_fpath.endswith(".h5"):
         out_fpath = '{}.h5'.format(out_fpath)
@@ -835,15 +881,18 @@ def my_collect_groups(out_fpath, groups, clobber=True):
         for dset in group['dsets']:
             if MultiYear.is_profile(group['source_files'], dset):
                 MultiYear.collect_profiles(out_fpath, group['source_files'],
-                                           dset, group=group['group'])
+                                           dset, group=group['group'],
+                                           config_file=config_file)
             else:
                 MultiYear.collect_means(out_fpath, group['source_files'],
-                                        dset, group=group['group'])
+                                        dset, group=group['group'],
+                                        config_file=config_file)
 
         pass_through_dsets = group.get('pass_through_dsets') or []
         for dset in pass_through_dsets:
             MultiYear.pass_through(out_fpath, group['source_files'],
-                                   dset, group=group['group'])
+                                   dset, group=group['group'],
+                                   config_file=config_file)
 
         runtime = (time.time() - t0) / 60
         logger.info('- {} collection completed in: {:.2f} min.'

--- a/reV/handlers/outputs.py
+++ b/reV/handlers/outputs.py
@@ -9,6 +9,7 @@ import sys
 import NRWAL
 import PySAM
 import rex
+import gaps
 from rex.outputs import Outputs as rexOutputs
 
 from reV.version import __version__
@@ -144,6 +145,7 @@ class Outputs(rexOutputs):
                         'pysam': PySAM.__version__,
                         'python': sys.version,
                         'nrwal': NRWAL.__version__,
+                        'gaps': gaps.__version__,
                         }
         versions = super().full_version_record
         versions.update(rev_versions)

--- a/reV/hybrids/hybrids.py
+++ b/reV/hybrids/hybrids.py
@@ -1260,7 +1260,10 @@ class Hybridization:
             except ValueError:
                 pass
 
-        run_attrs = add_to_run_attrs(config_file=config_file,
+        run_attrs = {"solar_fpath": self.data.solar_fpath,
+                     "wind_fpath": self.data.wind_fpath}
+        run_attrs = add_to_run_attrs(run_attrs=run_attrs,
+                                     config_file=config_file,
                                      module=ModuleName.HYBRIDS)
 
         Outputs.init_h5(

--- a/reV/hybrids/hybrids.py
+++ b/reV/hybrids/hybrids.py
@@ -17,13 +17,14 @@ from rex.utilities.utilities import to_records_array
 
 from reV.handlers.outputs import Outputs
 from reV.hybrids.hybrid_methods import HYBRID_METHODS
-from reV.utilities import SupplyCurveField
+from reV.utilities import SupplyCurveField, ModuleName
 from reV.utilities.exceptions import (
     FileInputError,
     InputError,
     InputWarning,
     OutputWarning,
 )
+from reV.utilities.cli_functions import add_to_run_attrs
 
 logger = logging.getLogger(__name__)
 
@@ -1108,7 +1109,8 @@ class Hybridization:
         """
         return self._profiles
 
-    def run(self, fout=None, save_hybrid_meta=True):
+    def run(self, fout=None, save_hybrid_meta=True, config_file=None,
+            project_dir=None):
         """Run hybridization of profiles and save to disc.
 
         Parameters
@@ -1119,6 +1121,14 @@ class Hybridization:
         save_hybrid_meta : bool, optional
             Flag to save hybrid SC table to hybrid rep profile output.
             By default, ``True``.
+        config_file : str, optional
+            Path to config file used for this hybrids run (if
+            applicable). This is used to store information about the run
+            in the output file attrs. By default, ``None``.
+        project_dir : str, optional
+            Path to run directory used for this hybrids run (if
+            applicable). This is used to store information about the run
+            in the output file attrs. By default, ``None``.
 
         Returns
         -------
@@ -1130,7 +1140,9 @@ class Hybridization:
         self.run_profiles()
 
         if fout is not None:
-            self.save_profiles(fout, save_hybrid_meta=save_hybrid_meta)
+            self.save_profiles(fout, save_hybrid_meta=save_hybrid_meta,
+                               config_file=config_file,
+                               project_dir=project_dir)
 
         logger.info("Hybridization of representative profiles complete!")
         return fout
@@ -1220,7 +1232,8 @@ class Hybridization:
             self._profiles[sp_name] + self._profiles[wp_name]
         )
 
-    def _init_h5_out(self, fout, save_hybrid_meta=True):
+    def _init_h5_out(self, fout, save_hybrid_meta=True, config_file=None,
+                     project_dir=None):
         """Initialize an output h5 file for hybrid profiles.
 
         Parameters
@@ -1229,6 +1242,14 @@ class Hybridization:
             Filepath to output h5 file.
         save_hybrid_meta : bool
             Flag to save hybrid SC table to hybrid rep profile output.
+        config_file : str, optional
+            Path to config file used for this hybrids run (if
+            applicable). This is used to store information about the run
+            in the output file attrs. By default, ``None``.
+        project_dir : str, optional
+            Path to run directory used for this hybrids run (if
+            applicable). This is used to store information about the run
+            in the output file attrs. By default, ``None``.
         """
         dsets = []
         shapes = {}
@@ -1250,6 +1271,10 @@ class Hybridization:
             except ValueError:
                 pass
 
+        run_attrs = add_to_run_attrs(config_file=config_file,
+                                     project_dir=project_dir,
+                                     module=ModuleName.HYBRIDS)
+
         Outputs.init_h5(
             fout,
             dsets,
@@ -1259,6 +1284,7 @@ class Hybridization:
             dtypes,
             meta,
             time_index=self.hybrid_time_index,
+            run_attrs=run_attrs,
         )
 
         if save_hybrid_meta:
@@ -1290,7 +1316,8 @@ class Hybridization:
             for dset, data in self.profiles.items():
                 out[dset] = data
 
-    def save_profiles(self, fout, save_hybrid_meta=True):
+    def save_profiles(self, fout, save_hybrid_meta=True, config_file=None,
+                      project_dir=None):
         """Initialize fout and save profiles.
 
         Parameters
@@ -1299,7 +1326,16 @@ class Hybridization:
             Filepath to output h5 file.
         save_hybrid_meta : bool
             Flag to save hybrid SC table to hybrid rep profile output.
+        config_file : str, optional
+            Path to config file used for this hybrids run (if
+            applicable). This is used to store information about the run
+            in the output file attrs. By default, ``None``.
+        project_dir : str, optional
+            Path to run directory used for this hybrids run (if
+            applicable). This is used to store information about the run
+            in the output file attrs. By default, ``None``.
         """
 
-        self._init_h5_out(fout, save_hybrid_meta=save_hybrid_meta)
+        self._init_h5_out(fout, save_hybrid_meta=save_hybrid_meta,
+                          config_file=config_file, project_dir=project_dir)
         self._write_h5_out(fout, save_hybrid_meta=save_hybrid_meta)

--- a/reV/hybrids/hybrids.py
+++ b/reV/hybrids/hybrids.py
@@ -1109,8 +1109,7 @@ class Hybridization:
         """
         return self._profiles
 
-    def run(self, fout=None, save_hybrid_meta=True, config_file=None,
-            project_dir=None):
+    def run(self, fout=None, save_hybrid_meta=True, config_file=None):
         """Run hybridization of profiles and save to disc.
 
         Parameters
@@ -1125,10 +1124,6 @@ class Hybridization:
             Path to config file used for this hybrids run (if
             applicable). This is used to store information about the run
             in the output file attrs. By default, ``None``.
-        project_dir : str, optional
-            Path to run directory used for this hybrids run (if
-            applicable). This is used to store information about the run
-            in the output file attrs. By default, ``None``.
 
         Returns
         -------
@@ -1141,8 +1136,7 @@ class Hybridization:
 
         if fout is not None:
             self.save_profiles(fout, save_hybrid_meta=save_hybrid_meta,
-                               config_file=config_file,
-                               project_dir=project_dir)
+                               config_file=config_file)
 
         logger.info("Hybridization of representative profiles complete!")
         return fout
@@ -1232,8 +1226,7 @@ class Hybridization:
             self._profiles[sp_name] + self._profiles[wp_name]
         )
 
-    def _init_h5_out(self, fout, save_hybrid_meta=True, config_file=None,
-                     project_dir=None):
+    def _init_h5_out(self, fout, save_hybrid_meta=True, config_file=None):
         """Initialize an output h5 file for hybrid profiles.
 
         Parameters
@@ -1244,10 +1237,6 @@ class Hybridization:
             Flag to save hybrid SC table to hybrid rep profile output.
         config_file : str, optional
             Path to config file used for this hybrids run (if
-            applicable). This is used to store information about the run
-            in the output file attrs. By default, ``None``.
-        project_dir : str, optional
-            Path to run directory used for this hybrids run (if
             applicable). This is used to store information about the run
             in the output file attrs. By default, ``None``.
         """
@@ -1272,7 +1261,6 @@ class Hybridization:
                 pass
 
         run_attrs = add_to_run_attrs(config_file=config_file,
-                                     project_dir=project_dir,
                                      module=ModuleName.HYBRIDS)
 
         Outputs.init_h5(
@@ -1316,8 +1304,7 @@ class Hybridization:
             for dset, data in self.profiles.items():
                 out[dset] = data
 
-    def save_profiles(self, fout, save_hybrid_meta=True, config_file=None,
-                      project_dir=None):
+    def save_profiles(self, fout, save_hybrid_meta=True, config_file=None):
         """Initialize fout and save profiles.
 
         Parameters
@@ -1330,12 +1317,8 @@ class Hybridization:
             Path to config file used for this hybrids run (if
             applicable). This is used to store information about the run
             in the output file attrs. By default, ``None``.
-        project_dir : str, optional
-            Path to run directory used for this hybrids run (if
-            applicable). This is used to store information about the run
-            in the output file attrs. By default, ``None``.
         """
 
         self._init_h5_out(fout, save_hybrid_meta=save_hybrid_meta,
-                          config_file=config_file, project_dir=project_dir)
+                          config_file=config_file)
         self._write_h5_out(fout, save_hybrid_meta=save_hybrid_meta)

--- a/reV/rep_profiles/cli_rep_profiles.py
+++ b/reV/rep_profiles/cli_rep_profiles.py
@@ -81,7 +81,7 @@ def _set_split_keys(config, out_dir, job_name, analysis_years):
     """Set the gen_fpath, fout, and cf_dset keys"""
 
     job_name = job_name.replace("rep_profiles", "rep-profiles")
-    cf_dset = config.get("cf_dset")
+    cf_dset = config.get("cf_dset", "cf_profile")
     gen_fpath = config.get("gen_fpath")
     if analysis_years[0] is not None and '{}' in cf_dset:
         config["gen_fpath"] = [gen_fpath for _ in analysis_years]

--- a/reV/utilities/cli_functions.py
+++ b/reV/utilities/cli_functions.py
@@ -2,7 +2,9 @@
 """
 General CLI utility functions.
 """
+import os
 import logging
+from copy import deepcopy
 from warnings import warn
 
 import pandas as pd
@@ -157,3 +159,41 @@ def compile_descriptions(cols=None):
         data.append((str(scf), scf.units, scf.description))
 
     return pd.DataFrame(data, columns=["reV Column", "Units", "Description"])
+
+
+def add_to_run_attrs(run_attrs=None, config_file=None, project_dir=None,
+                     module=ModuleName.GENERATION):
+    """Add config and project directory to run attrs
+
+    Parameters
+    ----------
+    run_attrs : dict, optional
+        Existing `run_attrs` (if any). By default, ``None``.
+    config_file : str, optional
+        Path to config file used for this module's run (if applicable).
+        This is used to store the run config in the output attrs.
+        By default, ``None``.
+    project_dir : _type_, optional
+        Path to run directory used for this module's run (if
+        applicable). This is used to store information about the run
+        in the output attrs. By default, ``None``.
+    module : :obj:`~reV.utilities.ModuleName`, optional
+        Module that this run represents.
+        By default, ``ModuleName.GENERATION``.
+
+    Returns
+    -------
+    dict
+        Run attributes that can be written to the file's attrs.
+    """
+    out = {}
+    if run_attrs:
+        out = deepcopy(run_attrs)
+
+    out["run_directory"] = str(project_dir)
+    out[f"{module}_config"] = "{}"
+    if config_file and os.path.exists(config_file):
+        with open(config_file, "r") as fh:
+            out[f"{module}_config"] = fh.read()
+
+    return out

--- a/reV/utilities/cli_functions.py
+++ b/reV/utilities/cli_functions.py
@@ -161,7 +161,7 @@ def compile_descriptions(cols=None):
     return pd.DataFrame(data, columns=["reV Column", "Units", "Description"])
 
 
-def add_to_run_attrs(run_attrs=None, config_file=None, project_dir=None,
+def add_to_run_attrs(run_attrs=None, config_file=None,
                      module=ModuleName.GENERATION):
     """Add config and project directory to run attrs
 
@@ -173,10 +173,6 @@ def add_to_run_attrs(run_attrs=None, config_file=None, project_dir=None,
         Path to config file used for this module's run (if applicable).
         This is used to store the run config in the output attrs.
         By default, ``None``.
-    project_dir : _type_, optional
-        Path to run directory used for this module's run (if
-        applicable). This is used to store information about the run
-        in the output attrs. By default, ``None``.
     module : :obj:`~reV.utilities.ModuleName`, optional
         Module that this run represents.
         By default, ``ModuleName.GENERATION``.
@@ -190,7 +186,7 @@ def add_to_run_attrs(run_attrs=None, config_file=None, project_dir=None,
     if run_attrs:
         out = deepcopy(run_attrs)
 
-    out["run_directory"] = str(project_dir)
+    out[f"{module}_config_fp"] = str(config_file)
     out[f"{module}_config"] = "{}"
     if config_file and os.path.exists(config_file):
         with open(config_file, "r") as fh:

--- a/tests/test_bespoke.py
+++ b/tests/test_bespoke.py
@@ -1750,6 +1750,12 @@ def test_cli(runner, clear_loggers):
                 assert f[dset].shape[1] == len(meta)
                 assert f[dset].any()  # not all zeros
 
+            assert "bespoke_config_fp" in f.h5.attrs
+            assert "bespoke_config" in f.h5.attrs
+
+            assert f.h5.attrs["bespoke_config_fp"] == config_path
+            assert f.h5.attrs["bespoke_config"] == json.dumps(config)
+
         clear_loggers()
 
 

--- a/tests/test_econ_lcoe.py
+++ b/tests/test_econ_lcoe.py
@@ -231,6 +231,11 @@ def test_econ_from_config(runner, clear_loggers):
             for output in LCOE_REQUIRED_OUTPUTS:
                 assert output in f.datasets
 
+            assert "econ_config_fp" in f.h5.attrs
+            assert "econ_config" in f.h5.attrs
+            assert f.h5.attrs['econ_config_fp'] == config_path
+            assert f.h5.attrs['econ_config'] == json.dumps(config)
+
         with h5py.File(r1f, mode='r') as f:
             r1_lcoe = f['pv']['lcoefcr'][0, 0:10] * 1000
 

--- a/tests/test_gen_config.py
+++ b/tests/test_gen_config.py
@@ -94,12 +94,10 @@ def test_gen_from_config(runner, tech, clear_loggers):
         # get reV 2.0 generation profiles from disk
         rev2_profiles = None
         flist = os.listdir(run_dir)
-        print(flist)
         for fname in flist:
             if fname.endswith('.h5'):
                 path = os.path.join(run_dir, fname)
                 with Outputs(path, 'r') as cf:
-
                     msg = 'cf_profile not written to disk'
                     assert 'cf_profile' in cf.datasets, msg
                     rev2_profiles = cf['cf_profile']
@@ -115,6 +113,11 @@ def test_gen_from_config(runner, tech, clear_loggers):
                         else:
                             assert output not in cf.datasets
 
+                    assert "run_directory" in cf.h5.attrs
+                    assert "generation_config" in cf.h5.attrs
+                    assert (json.loads(cf.h5.attrs["generation_config"])
+                            == config)
+
                 break
 
         if rev2_profiles is None:
@@ -129,9 +132,6 @@ def test_gen_from_config(runner, tech, clear_loggers):
 
         result = np.allclose(rev1_profiles, rev2_profiles,
                              rtol=RTOL, atol=ATOL)
-
-        print(rev1_profiles)
-        print(rev2_profiles)
 
         clear_loggers()
         msg = ('reV generation from config input failed for "{}" module!'

--- a/tests/test_gen_config.py
+++ b/tests/test_gen_config.py
@@ -113,7 +113,7 @@ def test_gen_from_config(runner, tech, clear_loggers):
                         else:
                             assert output not in cf.datasets
 
-                    assert "run_directory" in cf.h5.attrs
+                    assert "generation_config_fp" in cf.h5.attrs
                     assert "generation_config" in cf.h5.attrs
                     assert (json.loads(cf.h5.attrs["generation_config"])
                             == config)

--- a/tests/test_gen_config.py
+++ b/tests/test_gen_config.py
@@ -115,6 +115,7 @@ def test_gen_from_config(runner, tech, clear_loggers):
 
                     assert "generation_config_fp" in cf.h5.attrs
                     assert "generation_config" in cf.h5.attrs
+                    assert cf.h5.attrs["generation_config_fp"] == config_path
                     assert (json.loads(cf.h5.attrs["generation_config"])
                             == config)
 

--- a/tests/test_handlers_multiyear.py
+++ b/tests/test_handlers_multiyear.py
@@ -205,6 +205,16 @@ def test_cli(runner, clear_loggers):
             assert np.allclose(res['pass_through_2'],
                                2 * np.arange(len(res.meta)))
 
+            assert "multi-year_config_fp" in res.h5.attrs
+            assert "multi-year_config" in res.h5.attrs
+
+            assert res.h5.attrs["multi-year_config_fp"] == fp_config
+            assert res.h5.attrs["multi-year_config"] == json.dumps(config)
+
+            assert "multi-year_source_files" in res.h5.attrs
+            assert (set(json.loads(res.h5.attrs["multi-year_source_files"]))
+                    == set(temp_h5_files))
+
         clear_loggers()
 
 
@@ -268,6 +278,16 @@ def test_cli_single_file(runner, clear_loggers):
                                1 * np.arange(len(res.meta)))
             assert np.allclose(res['pass_through_2'],
                                2 * np.arange(len(res.meta)))
+
+            assert "multi-year_config_fp" in res.h5.attrs
+            assert "multi-year_config" in res.h5.attrs
+
+            assert res.h5.attrs["multi-year_config_fp"] == fp_config
+            assert res.h5.attrs["multi-year_config"] == json.dumps(config)
+
+            assert "multi-year_source_files" in res.h5.attrs
+            assert (json.loads(res.h5.attrs["multi-year_source_files"])
+                    == [fp_in])
 
         clear_loggers()
 

--- a/tests/test_hybrids.py
+++ b/tests/test_hybrids.py
@@ -812,7 +812,7 @@ def test_hybrids_cli_from_config(
             assert np.all(meta_from_file == h.hybrid_meta.fillna(fv))
             assert np.all(f.time_index.values == h.hybrid_time_index.values)
 
-            assert "run_directory" in f.h5.attrs
+            assert "hybrids_config_fp" in f.h5.attrs
             assert "hybrids_config" in f.h5.attrs
             assert json.loads(f.h5.attrs["hybrids_config"]) == config
 

--- a/tests/test_hybrids.py
+++ b/tests/test_hybrids.py
@@ -736,7 +736,7 @@ def test_hybrids_data_contains_col(solar_fpath, wind_fpath):
      f"solar_{SupplyCurveField.AREA_SQ_KM}"
      f"/wind_{SupplyCurveField.AREA_SQ_KM}"],
 )
-@pytest.mark.parametrize("ratio_bounds", [None, (0.5, 1.5), (0.3, 3.6)])
+@pytest.mark.parametrize("ratio_bounds", [None, [0.5, 1.5], [0.3, 3.6]])
 @pytest.mark.parametrize("input_combination", [(False, False), (True, True)])
 def test_hybrids_cli_from_config(
     runner, half_hour, ratio, ratio_bounds, input_combination, clear_loggers,
@@ -811,6 +811,10 @@ def test_hybrids_cli_from_config(
             meta_from_file = f.meta.fillna(fv).replace("nan", fv)
             assert np.all(meta_from_file == h.hybrid_meta.fillna(fv))
             assert np.all(f.time_index.values == h.hybrid_time_index.values)
+
+            assert "run_directory" in f.h5.attrs
+            assert "hybrids_config" in f.h5.attrs
+            assert json.loads(f.h5.attrs["hybrids_config"]) == config
 
         clear_loggers()
 

--- a/tests/test_hybrids.py
+++ b/tests/test_hybrids.py
@@ -812,8 +812,14 @@ def test_hybrids_cli_from_config(
             assert np.all(meta_from_file == h.hybrid_meta.fillna(fv))
             assert np.all(f.time_index.values == h.hybrid_time_index.values)
 
+            assert "solar_fpath" in f.h5.attrs
+            assert "wind_fpath" in f.h5.attrs
             assert "hybrids_config_fp" in f.h5.attrs
             assert "hybrids_config" in f.h5.attrs
+
+            assert f.h5.attrs["solar_fpath"] == sfp
+            assert f.h5.attrs["wind_fpath"] == wfp
+            assert f.h5.attrs["hybrids_config_fp"] == config_path
             assert json.loads(f.h5.attrs["hybrids_config"]) == config
 
         clear_loggers()


### PR DESCRIPTION
reV now stores the config file as a file attribute if/when reV is run from the command line. This should help with traceability and reproducibility of results.